### PR TITLE
Ensure same traceId is used for sampling and downstream generated spans.

### DIFF
--- a/beeline-core/src/main/java/io/honeycomb/beeline/tracing/SpanBuilderFactory.java
+++ b/beeline-core/src/main/java/io/honeycomb/beeline/tracing/SpanBuilderFactory.java
@@ -261,9 +261,9 @@ public class SpanBuilderFactory {
             return sampleRate > 0 ? createSendingSpan(sampleRate, traceId) : Span.getNoopInstance();
         }
 
-        private Span createSendingSpan(final int sampleRate, String traceId) {
+        private Span createSendingSpan(final int sampleRate, final String traceId) {
             final PropagationContext context = new PropagationContext(
-                traceId,parentContext.getSpanId(), parentContext.getDataset(), parentContext.getTraceFields()
+                traceId, parentContext.getSpanId(), parentContext.getDataset(), parentContext.getTraceFields()
             );
             final Span span = new SendingSpan(
                 spanName,

--- a/beeline-core/src/main/java/io/honeycomb/beeline/tracing/SpanBuilderFactory.java
+++ b/beeline-core/src/main/java/io/honeycomb/beeline/tracing/SpanBuilderFactory.java
@@ -258,11 +258,10 @@ public class SpanBuilderFactory {
             final String traceId = parentContext.isTraced() ? parentContext.getTraceId() : idProvider.generateId();
             final int sampleRate = traceSampler.sample(traceId);
             LOG.debug("Building span - sampling decision for traceId '{}' is '{}'", traceId, sampleRate);
-            return sampleRate > 0 ? createSendingSpan(sampleRate) : Span.getNoopInstance();
+            return sampleRate > 0 ? createSendingSpan(sampleRate, traceId) : Span.getNoopInstance();
         }
 
-        private Span createSendingSpan(final int sampleRate) {
-            final String traceId = parentContext.isTraced() ? parentContext.getTraceId() : idProvider.generateId();
+        private Span createSendingSpan(final int sampleRate, String traceId) {
             final PropagationContext context = new PropagationContext(
                 traceId,parentContext.getSpanId(), parentContext.getDataset(), parentContext.getTraceFields()
             );


### PR DESCRIPTION
Ensure that the traceId that passed sampling gets passed in to the sampling span.