### PR TITLE
http-propagation-utilities (honey-7):

### DIFF
--- a/beeline-core/src/main/java/io/honeycomb/beeline/tracing/Beeline.java
+++ b/beeline-core/src/main/java/io/honeycomb/beeline/tracing/Beeline.java
@@ -1,11 +1,14 @@
 package io.honeycomb.beeline.tracing;
 
+import io.honeycomb.beeline.tracing.propagation.HttpServerRequestAdapter;
 import io.honeycomb.beeline.tracing.propagation.Propagation;
 import io.honeycomb.beeline.tracing.propagation.PropagationContext;
 import io.honeycomb.beeline.tracing.sampling.DeterministicTraceSampler;
 import io.honeycomb.beeline.tracing.sampling.Sampling;
 import io.honeycomb.beeline.tracing.utils.TraceFieldConstants;
 import io.honeycomb.libhoney.utils.Assert;
+
+import java.util.ArrayList;
 
 /**
  * The Beeline class is the main/most-convenient point of interaction with traces in a Beeline-instrumented application.
@@ -144,6 +147,41 @@ public class Beeline {
      */
     public void addField(final String key, final Object value) {
         tracer.getActiveSpan().addField(TraceFieldConstants.USER_FIELD_NAMESPACE + key, value);
+    }
+
+    /**
+     * A convenience method that starts a trace.
+     * <p>
+     * Typically this would be invoked when a service receives an external request, but before the request is
+     * processed by the service. For example in an HTTP Servlet filter before
+     * {@code javax.servlet.FilterChain#doFilter(ServletRequest, ServletResponse)}} is invoked.
+     * <p>
+     * The {@code parentContext} contains information that is needed to continue traces across process boundaries, e.g.
+     * whether the external service making the request was also traced. If the external service was also traced, the
+     * span returned by this method will:
+     * <p>
+     * - share the same trace ID <br>
+     * - be the child of the span that represents the call to this service
+     * <p>
+     * The returned span is also accessible via {@link #getActiveSpan()} because it becomes the current span.
+     *
+     * @param spanName the name of the span to create
+     * @param parentContext the parent context containing inter-process tracing information
+     * @param serviceName the name of the service using this method
+     * @return the new current span
+     * @see Tracer#startTrace(Span)
+     * @see io.honeycomb.beeline.tracing.propagation.HttpServerPropagator#startPropagation(HttpServerRequestAdapter) for
+     * an existing solution for starting (and closing) traces for incoming requests to an HTTP server.
+     */
+    public Span startTrace(final String spanName, final PropagationContext parentContext, final String serviceName) {
+        return tracer.startTrace(
+            factory
+                .createBuilder()
+                .setSpanName(spanName)
+                .setServiceName(serviceName)
+                .setParentContext(parentContext)
+                .build()
+        );
     }
 
     public Tracer getTracer() {

--- a/beeline-core/src/main/java/io/honeycomb/beeline/tracing/propagation/HttpClientPropagator.java
+++ b/beeline-core/src/main/java/io/honeycomb/beeline/tracing/propagation/HttpClientPropagator.java
@@ -17,7 +17,7 @@ import static io.honeycomb.beeline.tracing.utils.TraceFieldConstants.*;
  * HttpClientRequestAdapter adaptedHttpRequest = new HttpClientRequestAdapter(actualHttpRequest);
  * HttpClientResponseAdapter adaptedHttpResponse = null;
  * Throwable error = null;
- * Span span = clientPropagator.startPropagation(spanName, adaptedHttpRequest);
+ * Span span = clientPropagator.startPropagation(adaptedHttpRequest);
  * try {
  *   actualHttpResponse = makeClientCall(actualHttpRequest);
  *   adaptedHttpResponse = new HttpClientResponseAdapter(actualHttpResponse);

--- a/beeline-core/src/main/java/io/honeycomb/beeline/tracing/propagation/HttpClientPropagator.java
+++ b/beeline-core/src/main/java/io/honeycomb/beeline/tracing/propagation/HttpClientPropagator.java
@@ -1,0 +1,127 @@
+package io.honeycomb.beeline.tracing.propagation;
+
+import io.honeycomb.beeline.tracing.Span;
+import io.honeycomb.beeline.tracing.Tracer;
+import io.honeycomb.libhoney.shaded.org.apache.http.HttpHeaders;
+
+import java.util.function.Function;
+
+import static io.honeycomb.beeline.tracing.utils.TraceFieldConstants.*;
+
+/**
+ * Provides straightforward instrumentation of an an HTTP client call, while also adding a
+ * standardized set of span fields.
+ *
+ * <p>Example instrumentation for a synchronous client call:
+ * <pre>{@code
+ * HttpClientRequestAdapter adaptedHttpRequest = new HttpClientRequestAdapter(actualHttpRequest);
+ * HttpClientResponseAdapter adaptedHttpResponse = null;
+ * Throwable error = null;
+ * Span span = clientPropagator.startPropagation(spanName, adaptedHttpRequest);
+ * try {
+ *   actualHttpResponse = makeClientCall(actualHttpRequest);
+ *   adaptedHttpResponse = new HttpClientResponseAdapter(actualHttpResponse);
+ * } catch (Exception ex) {
+ *   error = ex;
+ *   throw ex;
+ * } finally {
+ *   clientPropagator.endPropagation(adaptedHttpResponse, error, span);
+ * }
+ * }</pre>
+ *
+ *<p>
+ * The API is based on Brave's HTTP utilities under {@code brave.http}.
+ */
+public class HttpClientPropagator {
+    public static final String HTTP_CLIENT_SPAN_TYPE = "http_client";
+
+    private final Tracer tracer;
+    private final PropagationCodec<String> propagationCodec;
+    private final Function<HttpClientRequestAdapter, String> requestToSpanName;
+
+    /**
+     * Note that the {@code requestToSpanName} function should produce low cardinality span names; Honeycomb works
+     * best when this is the case.
+     *
+     * @param tracer the tracer
+     * @param requestToSpanName a function from request to span name
+     */
+    public HttpClientPropagator(final Tracer tracer, final Function<HttpClientRequestAdapter, String> requestToSpanName) {
+        this(tracer, Propagation.honeycombHeaderV1(), requestToSpanName);
+    }
+
+    //Exposed for unit testing
+    protected HttpClientPropagator(final Tracer tracer,
+                                   final PropagationCodec<String> propagationCodec,
+                                   final Function<HttpClientRequestAdapter, String> requestToSpanName) {
+        this.tracer = tracer;
+        this.propagationCodec = propagationCodec;
+        this.requestToSpanName = requestToSpanName;
+    }
+
+    /**
+     * Creates a child span for this HTTP client request and adds the standardized fields to it.
+     *
+     * @param httpRequest the adapted HTTP client request
+     * @return the child span
+     */
+    public Span startPropagation(final HttpClientRequestAdapter httpRequest) {
+        final Span childSpan = tracer.startChildSpan(requestToSpanName.apply(httpRequest));
+        addRequestFields(httpRequest, childSpan);
+        propagateTrace(httpRequest, childSpan);
+        return childSpan;
+    }
+
+    /**
+     * Adds standard span fields based on data in the HTTP response or the {@code error}.
+     * Closes the HTTP client call span.
+     * <p>
+     * The {@code httpResponse} and the {@code error} are both allowed to be {@code null}.
+     *
+     * @param httpResponse the adapted HTTP response, may be {@code null}
+     * @param error an error that was thrown during the HTTP client call, may be {@code null}
+     * @param span the span for the HTTP client call
+     */
+    public void endPropagation(final HttpClientResponseAdapter httpResponse, final Throwable error, final Span span) {
+        try {
+            if (error != null) {
+                addErrorFields(error, span);
+            } else if (httpResponse != null) {
+                addResponseFields(span, httpResponse);
+            }
+        } finally {
+            span.close();
+        }
+    }
+
+    private void addRequestFields(final HttpClientRequestAdapter httpRequest, final Span childSpan) {
+        httpRequest.getFirstHeader(HttpHeaders.CONTENT_TYPE).ifPresent(v -> childSpan.addField(CLIENT_REQUEST_CONTENT_TYPE_FIELD, v));
+        httpRequest.getPath().ifPresent(p -> childSpan.addField(CLIENT_REQUEST_PATH_FIELD, p));
+        if (httpRequest.getContentLength() > 0) {
+            childSpan.addField(CLIENT_REQUEST_CONTENT_LENGTH_FIELD, httpRequest.getContentLength());
+        }
+        childSpan
+            .addField(TYPE_FIELD, HTTP_CLIENT_SPAN_TYPE)
+            .addField(CLIENT_REQUEST_METHOD_FIELD, httpRequest.getMethod());
+    }
+
+    private void propagateTrace(final HttpClientRequestAdapter httpRequest, final Span childSpan) {
+        propagationCodec.encode(childSpan.getTraceContext())
+            .ifPresent(headerValue ->
+                httpRequest.addHeader(HttpHeaderV1PropagationCodec.HONEYCOMB_TRACE_HEADER, headerValue)
+            );
+    }
+
+    private void addResponseFields(final Span childSpan, final HttpClientResponseAdapter httpResponse) {
+        childSpan.addField(CLIENT_RESPONSE_STATUS_CODE_FIELD, httpResponse.getStatus());
+        httpResponse.getFirstHeader(HttpHeaders.CONTENT_LENGTH).ifPresent(v -> childSpan.addField(CLIENT_RESPONSE_CONTENT_LENGTH, v));
+        httpResponse.getFirstHeader(HttpHeaders.CONTENT_TYPE).ifPresent(v -> childSpan.addField(CLIENT_RESPONSE_CONTENT_TYPE_FIELD, v));
+    }
+
+    private void addErrorFields(final Throwable ex, final Span childSpan) {
+        childSpan.addField(CLIENT_REQUEST_ERROR_FIELD, ex.getClass().getSimpleName());
+        if (ex.getMessage() != null) {
+            childSpan.addField(CLIENT_REQUEST_ERROR_DETAIL_FIELD, ex.getMessage());
+        }
+    }
+}

--- a/beeline-core/src/main/java/io/honeycomb/beeline/tracing/propagation/HttpClientPropagator.java
+++ b/beeline-core/src/main/java/io/honeycomb/beeline/tracing/propagation/HttpClientPropagator.java
@@ -40,8 +40,10 @@ public class HttpClientPropagator {
     private final Function<HttpClientRequestAdapter, String> requestToSpanName;
 
     /**
-     * Note that the {@code requestToSpanName} function should produce low cardinality span names; Honeycomb works
-     * best when this is the case.
+     * Create an HttpClientPropagator for tracing HTTP client requests.
+     * <p>
+     * {@code requestToSpanName} allows you to dynamically name the HTTP client spans such that the name
+     * reflects the operation, e.g. based on HTTP method or request path used.
      *
      * @param tracer the tracer
      * @param requestToSpanName a function from request to span name

--- a/beeline-core/src/main/java/io/honeycomb/beeline/tracing/propagation/HttpClientRequestAdapter.java
+++ b/beeline-core/src/main/java/io/honeycomb/beeline/tracing/propagation/HttpClientRequestAdapter.java
@@ -8,14 +8,14 @@ import java.util.Optional;
  */
 public interface HttpClientRequestAdapter {
     /**
-     * Returns the HTTP method of the request as a plain String.
+     * Returns the HTTP method of the request.
      * @return the HTTP method
      */
     String getMethod();
     /**
-     * Returns the path component of this URI.
+     * Returns the path requested.
      *
-     * @return  The path component of this URI,
+     * @return  The path,
      *          or {@code Optional.empty()} if the path is undefined
      */
     Optional<String> getPath();

--- a/beeline-core/src/main/java/io/honeycomb/beeline/tracing/propagation/HttpClientRequestAdapter.java
+++ b/beeline-core/src/main/java/io/honeycomb/beeline/tracing/propagation/HttpClientRequestAdapter.java
@@ -1,0 +1,39 @@
+package io.honeycomb.beeline.tracing.propagation;
+
+import java.util.Optional;
+
+/**
+ * Adapt an HTTP request that is about to be sent by a client. This is so it can be
+ * processed by an {@link HttpClientPropagator}.
+ */
+public interface HttpClientRequestAdapter {
+    /**
+     * Returns the HTTP method of the request as a plain String.
+     * @return the HTTP method
+     */
+    String getMethod();
+    /**
+     * Returns the path component of this URI.
+     *
+     * @return  The path component of this URI,
+     *          or {@code Optional.empty()} if the path is undefined
+     */
+    Optional<String> getPath();
+    /**
+     * Return the length in bytes of the request body.
+     * @return the request content length
+     */
+    int getContentLength();
+    /**
+     * Return the first header value for the header name.
+     * @param name the header name
+     * @return the first header value, or {@code Optional.empty()} if none
+     */
+    Optional<String> getFirstHeader(String name);
+    /**
+     * Add a header to the request
+     * @param name header name
+     * @param value header value
+     */
+    void addHeader(String name, String value);
+}

--- a/beeline-core/src/main/java/io/honeycomb/beeline/tracing/propagation/HttpClientResponseAdapter.java
+++ b/beeline-core/src/main/java/io/honeycomb/beeline/tracing/propagation/HttpClientResponseAdapter.java
@@ -8,7 +8,7 @@ import java.util.Optional;
  */
 public interface HttpClientResponseAdapter {
     /**
-     * Return the HTTP status code as an integer.
+     * Return the HTTP status code.
      * @return the HTTP status code.
      */
     int getStatus();

--- a/beeline-core/src/main/java/io/honeycomb/beeline/tracing/propagation/HttpClientResponseAdapter.java
+++ b/beeline-core/src/main/java/io/honeycomb/beeline/tracing/propagation/HttpClientResponseAdapter.java
@@ -1,0 +1,21 @@
+package io.honeycomb.beeline.tracing.propagation;
+
+import java.util.Optional;
+
+/**
+ * Adapt an HTTP response that has been received by a client. This is so it can be
+ * processed by an {@link HttpClientPropagator}.
+ */
+public interface HttpClientResponseAdapter {
+    /**
+     * Return the HTTP status code as an integer.
+     * @return the HTTP status code.
+     */
+    int getStatus();
+    /**
+     * Return the first header value for the header name.
+     * @param name the header name
+     * @return the first header value, or {@code Optional.empty()} if none
+     */
+    Optional<String> getFirstHeader(String name);
+}

--- a/beeline-core/src/main/java/io/honeycomb/beeline/tracing/propagation/HttpServerPropagator.java
+++ b/beeline-core/src/main/java/io/honeycomb/beeline/tracing/propagation/HttpServerPropagator.java
@@ -1,0 +1,144 @@
+package io.honeycomb.beeline.tracing.propagation;
+
+import io.honeycomb.beeline.tracing.Beeline;
+import io.honeycomb.beeline.tracing.Span;
+import io.honeycomb.libhoney.shaded.org.apache.http.HttpHeaders;
+
+import java.util.function.Function;
+
+import static io.honeycomb.beeline.tracing.propagation.HttpHeaderV1PropagationCodec.HONEYCOMB_TRACE_HEADER;
+import static io.honeycomb.beeline.tracing.utils.TraceFieldConstants.*;
+
+/**
+ * Provides straightforward instrumentation of an an HTTP server, while also adding a
+ * standardized set of span fields.
+ *
+ * <p>Example instrumentation for synchronous server code:
+ * <pre>{@code
+ * HttpServerRequestAdapter adaptedHttpRequest = new HttpServerRequestAdapter(actualHttpRequest);
+ * HttpServerResponseAdapter adaptedHttpResponse = null;
+ * Throwable error = null;
+ * Span span = serverPropagator.startPropagation(adaptedHttpRequest);
+ * try {
+ *   actualHttpResponse = doServerWork(actualHttpRequest);
+ *   adaptedHttpResponse = new HttpServerResponseAdapter(actualHttpResponse);
+ * } catch (Exception ex) {
+ *   error = ex;
+ *   throw ex;
+ * } finally {
+ *   serverPropagator.endPropagation(adaptedHttpResponse, error, span);
+ * }
+ * }</pre>
+ *
+ * <p>
+ * The API is based on Brave's HTTP utilities under {@code brave.http}.
+ */
+public class HttpServerPropagator {
+    public static final String OPERATION_TYPE_HTTP_SERVER = "http_server";
+
+    private final Function<HttpServerRequestAdapter, String> requestToSpanName;
+    private final String serviceName;
+    private final HttpServerRequestSpanCustomizer spanCustomizer;
+    private final PropagationCodec<String> propagationCodec;
+    private final TraceStarter traceStarter;
+
+    /**
+     * Note that the {@code requestToSpanName} function should produce low cardinality span names; Honeycomb works
+     * best when this is the case.
+     *
+     * @param beeline the beeline
+     * @param serviceName the service name
+     * @param requestToSpanName a function from an HTTP request to a span name
+     */
+    public HttpServerPropagator(final Beeline beeline,
+                                final String serviceName,
+                                final Function<HttpServerRequestAdapter, String> requestToSpanName) {
+        this(serviceName, requestToSpanName, new HttpServerRequestSpanCustomizer(), Propagation.honeycombHeaderV1(), new TraceStarter(beeline));
+    }
+
+    // Exposed for unit testing
+    protected HttpServerPropagator(final String serviceName,
+                                final Function<HttpServerRequestAdapter, String> requestToSpanName,
+                                final HttpServerRequestSpanCustomizer spanCustomizer,
+                                final PropagationCodec<String> propagationCodec,
+                                final TraceStarter traceStarter) {
+        this.requestToSpanName = requestToSpanName;
+        this.serviceName = serviceName;
+        this.spanCustomizer = spanCustomizer;
+        this.propagationCodec = propagationCodec;
+        this.traceStarter = traceStarter;
+    }
+
+    /**
+     * Creates a root span for this HTTP server call and adds the standardized fields to it.
+     *
+     * @param httpRequest the adapted HTTP request
+     * @return the span
+     */
+    public Span startPropagation(final HttpServerRequestAdapter httpRequest) {
+        final String honeycombHeaderValue = httpRequest.getFirstHeader(HONEYCOMB_TRACE_HEADER).orElse(null);
+        //PropagationCodec#decode is null-safe
+        final PropagationContext decoded = propagationCodec.decode(honeycombHeaderValue);
+
+        final String spanName = requestToSpanName.apply(httpRequest);
+
+        final Span rootSpan = traceStarter.startTrace(spanName, decoded, serviceName);
+
+        spanCustomizer.customize(rootSpan, httpRequest);
+        return rootSpan;
+    }
+
+    /**
+     * Adds standard span fields based on data in the HTTP response or the {@code error}.
+     * Closes the HTTP server span.
+     * <p>
+     * The {@code httpResponse} and the {@code error} are both allowed to be {@code null}.
+     *
+     * @param httpResponse the adapted HTTP response, may be {@code null}
+     * @param error an error that was thrown when the HTTP server was processing the HTTP request, may be {@code null}
+     * @param span the span for the HTTP server call
+     */
+    public void endPropagation(final HttpServerResponseAdapter httpResponse, final Throwable error, final Span span) {
+        try {
+            if (span.isNoop()) {
+                return;
+            }
+
+            if (error != null) {
+                span.addField(REQUEST_ERROR_FIELD, error.getClass().getSimpleName());
+                if (error.getMessage() != null) {
+                    span.addField(REQUEST_ERROR_DETAIL_FIELD, error.getMessage());
+                }
+            } else if (httpResponse != null) {
+                httpResponse.getFirstHeader(HttpHeaders.CONTENT_TYPE).ifPresent(v -> span.addField(RESPONSE_CONTENT_TYPE_FIELD, v));
+                span.addField(STATUS_CODE_FIELD, httpResponse.getStatus());
+            }
+        } finally {
+            span.close();
+        }
+    }
+
+    /**
+     * Workaround until we have a decision on where to put this type of convenience method.
+     * At the moment, they are split between {@link io.honeycomb.beeline.tracing.Beeline}
+     * and {@link io.honeycomb.beeline.DefaultBeeline}.
+     * */
+    protected static class TraceStarter {
+        private final Beeline beeline;
+
+        protected TraceStarter(Beeline beeline) {
+            this.beeline = beeline;
+        }
+
+        protected Span startTrace(final String spanName, final PropagationContext parentContext, final String serviceName) {
+            return beeline.getTracer().startTrace(
+                beeline.getSpanBuilderFactory()
+                    .createBuilder()
+                    .setSpanName(spanName)
+                    .setServiceName(serviceName)
+                    .setParentContext(parentContext)
+                    .build()
+            );
+        }
+    }
+}

--- a/beeline-core/src/main/java/io/honeycomb/beeline/tracing/propagation/HttpServerRequestAdapter.java
+++ b/beeline-core/src/main/java/io/honeycomb/beeline/tracing/propagation/HttpServerRequestAdapter.java
@@ -10,15 +10,15 @@ import java.util.Optional;
  */
 public interface HttpServerRequestAdapter {
     /**
-     * Returns the HTTP method of the request as a plain String.
+     * Returns the HTTP method of the request.
      * @return the HTTP method
      */
     String getMethod();
 
     /**
-     * Returns the path component of this URI.
+     * Returns the path requested.
      *
-     * @return  The path component of this URI,
+     * @return  The path,
      *          or {@code Optional.empty()} if the path is undefined
      */
     Optional<String> getPath();
@@ -31,7 +31,7 @@ public interface HttpServerRequestAdapter {
     Optional<String> getFirstHeader(String name);
 
     /**
-     * Return the URI scheme.
+     * Return the URI scheme used in the request.
      * @return the scheme. Can return {@code Optional.empty()} if not available.
      */
     Optional<String> getScheme();
@@ -43,14 +43,14 @@ public interface HttpServerRequestAdapter {
     Optional<String> getHost();
 
     /**
-     * Returns the name and version of the protocol. For instance, HTTP/1.1.
+     * Returns the name and version of the HTTP protocol. For instance, HTTP/1.1.
      *
      * @return the HTTP version
      */
     String getHttpVersion();
 
     /**
-     * Indicates whether this request was made using a secure channel, such as HTTPS.
+     * Indicates whether this request used a secure channel, e.g. HTTPS.
      *
      * @return whether the request is secure
      */

--- a/beeline-core/src/main/java/io/honeycomb/beeline/tracing/propagation/HttpServerRequestAdapter.java
+++ b/beeline-core/src/main/java/io/honeycomb/beeline/tracing/propagation/HttpServerRequestAdapter.java
@@ -1,0 +1,77 @@
+package io.honeycomb.beeline.tracing.propagation;
+
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+
+/**
+ * Adapt an HTTP request that has been received by a server. This is so it can be
+ * processed by an {@link HttpServerPropagator}.
+ */
+public interface HttpServerRequestAdapter {
+    /**
+     * Returns the HTTP method of the request as a plain String.
+     * @return the HTTP method
+     */
+    String getMethod();
+
+    /**
+     * Returns the path component of this URI.
+     *
+     * @return  The path component of this URI,
+     *          or {@code Optional.empty()} if the path is undefined
+     */
+    Optional<String> getPath();
+
+    /**
+     * Return the first header value for the header name.
+     * @param name the header name
+     * @return the first header value, or {@code Optional.empty()} if none
+     */
+    Optional<String> getFirstHeader(String name);
+
+    /**
+     * Return the URI scheme.
+     * @return the scheme. Can return {@code Optional.empty()} if not available.
+     */
+    Optional<String> getScheme();
+
+    /**
+     * Return the host in the request.
+     * @return the host. Can return {@code Optional.empty()} if not available.
+     */
+    Optional<String> getHost();
+
+    /**
+     * Returns the name and version of the protocol. For instance, HTTP/1.1.
+     *
+     * @return the HTTP version
+     */
+    String getHttpVersion();
+
+    /**
+     * Indicates whether this request was made using a secure channel, such as HTTPS.
+     *
+     * @return whether the request is secure
+     */
+    boolean isSecure();
+
+    /**
+     * Returns the IP address of the client (or final proxy) that sent the request.
+     * @return the remote address
+     */
+    String getRemoteAddress();
+
+    /**
+     * Return the map of query parameters.
+     *
+     * @return the map, which may be empty if there are no query parameters.
+     */
+    Map<String, List<String>> getQueryParams();
+
+    /**
+     * Return the length in bytes of the request body.
+     * @return the request content length
+     */
+    int getContentLength();
+}

--- a/beeline-core/src/main/java/io/honeycomb/beeline/tracing/propagation/HttpServerRequestSpanCustomizer.java
+++ b/beeline-core/src/main/java/io/honeycomb/beeline/tracing/propagation/HttpServerRequestSpanCustomizer.java
@@ -1,0 +1,69 @@
+package io.honeycomb.beeline.tracing.propagation;
+
+import io.honeycomb.beeline.tracing.Span;
+import io.honeycomb.libhoney.shaded.org.apache.http.HttpHeaders;
+
+import java.util.List;
+import java.util.Map;
+
+import static io.honeycomb.beeline.tracing.utils.TraceFieldConstants.*;
+import static io.honeycomb.beeline.tracing.utils.TraceFieldConstants.REQUEST_AJAX_FIELD;
+import static io.honeycomb.beeline.tracing.utils.TraceFieldConstants.REQUEST_REMOTE_ADDRESS_FIELD;
+
+/**
+ * Customizes a span with information contained in an HTTP request received by the server.
+ * <p>
+ * This class is created for reuse so as not to violate DRY: it can be used in {@link HttpServerPropagator} and
+ * in the Servlet Instrumentation in the Spring Beeline.However, it is not open for extension as the fields that the
+ * instrumentation adds in this case are standardized.
+ */
+public final class HttpServerRequestSpanCustomizer {
+    private static final String X_REQUESTED_WITH_HEADER = "x-requested-with";
+    private static final String X_FORWARDED_FOR_HEADER = "x-forwarded-for";
+    private static final String X_FORWARDED_PROTO_HEADER = "x-forwarded-proto";
+
+    /**
+     * Customize a span by adding information from a HTTP request received by a server.
+     * Adds all of the standard Honeycomb fields.
+     * @param span the span
+     * @param httpServerRequestAdapter the http server request
+     */
+    public void customize(final Span span, final HttpServerRequestAdapter httpServerRequestAdapter) {
+        addHttpFields(span, httpServerRequestAdapter);
+    }
+
+    private void addHttpFields(final Span span, final HttpServerRequestAdapter request) {
+        span.addField(TYPE_FIELD, HttpServerPropagator.OPERATION_TYPE_HTTP_SERVER);
+        request.getFirstHeader(HttpHeaders.CONTENT_TYPE).ifPresent(v -> span.addField(REQUEST_CONTENT_TYPE_FIELD, v));
+        request.getFirstHeader(HttpHeaders.ACCEPT).ifPresent(v -> span.addField(REQUEST_ACCEPT_FIELD, v));
+        request.getFirstHeader(HttpHeaders.USER_AGENT).ifPresent(v -> span.addField(USER_AGENT_FIELD, v));
+        request.getFirstHeader(X_FORWARDED_FOR_HEADER).ifPresent(v -> span.addField(FORWARD_FOR_HEADER_FIELD, v));
+        request.getFirstHeader(X_FORWARDED_PROTO_HEADER).ifPresent(v -> span.addField(FORWARD_PROTO_HEADER_FIELD, v));
+
+        final Map<String, List<String>> queryParameters = request.getQueryParams();
+        if (!queryParameters.isEmpty()) {
+            span.addField(REQUEST_QUERY_PARAMS_FIELD, queryParameters);
+        }
+        final int contentLength = request.getContentLength();
+        if (contentLength > 0) {
+            span.addField(REQUEST_CONTENT_LENGTH_FIELD, contentLength);
+        }
+
+        request.getHost().ifPresent(v -> span.addField(REQUEST_HOST_FIELD, v));
+        request.getPath().ifPresent(v -> span.addField(REQUEST_PATH_FIELD, v));
+        request.getScheme().ifPresent(v -> span.addField(REQUEST_SCHEME_FIELD, v));
+
+        span
+            .addField(REQUEST_METHOD_FIELD, request.getMethod())
+            .addField(REQUEST_HTTP_VERSION_FIELD, request.getHttpVersion())
+            .addField(REQUEST_SECURE_FIELD, request.isSecure())
+            .addField(REQUEST_REMOTE_ADDRESS_FIELD, request.getRemoteAddress())
+            .addField(REQUEST_AJAX_FIELD, isAjax(request));
+    }
+
+    private boolean isAjax(final HttpServerRequestAdapter httpRequest) {
+        return httpRequest.getFirstHeader(X_REQUESTED_WITH_HEADER)
+            .map("XMLHttpRequest"::equalsIgnoreCase)
+            .orElse(false);
+    }
+}

--- a/beeline-core/src/main/java/io/honeycomb/beeline/tracing/propagation/HttpServerResponseAdapter.java
+++ b/beeline-core/src/main/java/io/honeycomb/beeline/tracing/propagation/HttpServerResponseAdapter.java
@@ -1,0 +1,22 @@
+package io.honeycomb.beeline.tracing.propagation;
+
+import java.util.Optional;
+
+/**
+ * Adapt an HTTP response that is about to be returned by a server. This is so it can be
+ * processed by an {@link HttpServerPropagator}.
+ */
+
+public interface HttpServerResponseAdapter {
+    /**
+     * Return the HTTP status code as an integer.
+     * @return the HTTP status code.
+     */
+    int getStatus();
+    /**
+     * Return the first header value for the header name.
+     * @param name the header name
+     * @return the first header value, or {@code Optional.empty()} if none
+     */
+    Optional<String> getFirstHeader(String name);
+}

--- a/beeline-core/src/main/java/io/honeycomb/beeline/tracing/propagation/HttpServerResponseAdapter.java
+++ b/beeline-core/src/main/java/io/honeycomb/beeline/tracing/propagation/HttpServerResponseAdapter.java
@@ -9,7 +9,7 @@ import java.util.Optional;
 
 public interface HttpServerResponseAdapter {
     /**
-     * Return the HTTP status code as an integer.
+     * Return the HTTP status code.
      * @return the HTTP status code.
      */
     int getStatus();

--- a/beeline-core/src/main/java/io/honeycomb/beeline/tracing/utils/TraceFieldConstants.java
+++ b/beeline-core/src/main/java/io/honeycomb/beeline/tracing/utils/TraceFieldConstants.java
@@ -71,10 +71,38 @@ public final class TraceFieldConstants {
     public static final String REQUEST_ERROR_FIELD          = "request.error";
     /** Detail about the error (e.g. the exception's message). */
     public static final String REQUEST_ERROR_DETAIL_FIELD   = "request.error_detail";
+    /** The request content type - if available. */
+    public static final String REQUEST_CONTENT_TYPE_FIELD   = "request.header.content_type";
+    /** The request accept header - if available. */
+    public static final String REQUEST_ACCEPT_FIELD         = "request.header.accept";
+    /** Any query parameters on the request URL. */
+    public static final String REQUEST_QUERY_PARAMS_FIELD   = "request.query";
+
+    // ========= http client namespace =========
+    /** */
+    public static final String CLIENT_REQUEST_PATH_FIELD            = "client.request.path";
+    /** */
+    public static final String CLIENT_REQUEST_METHOD_FIELD          = "client.request.method";
+    /** */
+    public static final String CLIENT_REQUEST_CONTENT_LENGTH_FIELD  = "client.request.content_length";
+    /** */
+    public static final String CLIENT_REQUEST_CONTENT_TYPE_FIELD    = "client.request.content_type";
+    /** */
+    public static final String CLIENT_REQUEST_ERROR_FIELD           = "client.request.error";
+    /** */
+    public static final String CLIENT_REQUEST_ERROR_DETAIL_FIELD    = "client.request.error_detail";
+    /** */
+    public static final String CLIENT_RESPONSE_CONTENT_TYPE_FIELD   = "client.response.content_type";
+    /** */
+    public static final String CLIENT_RESPONSE_STATUS_CODE_FIELD    = "client.response.status_code";
+    /** */
+    public static final String CLIENT_RESPONSE_CONTENT_LENGTH       = "client.response.content_length";
 
     // ========= response namespace =========
     /** The response status code. */
     public static final String STATUS_CODE_FIELD            = "response.status_code";
+    /** The response content type - if available. */
+    public static final String RESPONSE_CONTENT_TYPE_FIELD  = "response.header.content_type";
 
     //// ========= indicators of problems =========
     /** A child span sent as result of its parent being closed before it was closed. */

--- a/beeline-core/src/test/java/io/honeycomb/beeline/tracing/propagation/HttpClientPropagatorTest.java
+++ b/beeline-core/src/test/java/io/honeycomb/beeline/tracing/propagation/HttpClientPropagatorTest.java
@@ -1,0 +1,127 @@
+package io.honeycomb.beeline.tracing.propagation;
+
+import io.honeycomb.beeline.tracing.Span;
+import io.honeycomb.beeline.tracing.Tracer;
+import io.honeycomb.libhoney.shaded.org.apache.http.HttpHeaders;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.Mock;
+import org.mockito.junit.MockitoJUnitRunner;
+
+import java.util.Optional;
+
+import static io.honeycomb.beeline.tracing.propagation.MockSpanUtils.stubFluentCalls;
+import static io.honeycomb.beeline.tracing.utils.TraceFieldConstants.*;
+import static org.mockito.Mockito.*;
+
+@RunWith(MockitoJUnitRunner.class)
+public class HttpClientPropagatorTest {
+    private static final String EXPECTED_TRACE_HEADER = "traceHeader1";
+    private static final String EXPECTED_SPAN_NAME = "expectedSpanName";
+
+    @Mock
+    private Tracer mockTracer;
+    @Mock
+    private Span mockSpan;
+    @Mock
+    private HttpClientRequestAdapter mockHttpRequest;
+    @Mock
+    private HttpClientResponseAdapter mockHttpResponse;
+    @Mock
+    private PropagationCodec<String> mockPropagationCodec;
+
+    private HttpClientPropagator httpClientPropagator;
+
+    @Before
+    public void setUp() {
+        stubFluentCalls(mockSpan);
+        httpClientPropagator = new HttpClientPropagator(mockTracer, mockPropagationCodec, r -> EXPECTED_SPAN_NAME);
+    }
+
+    @Test
+    public void whenStartPropagation_traceHeaderIsAdded_onlyRequiredSpanFieldsAreAdded() {
+        when(mockTracer.startChildSpan(EXPECTED_SPAN_NAME)).thenReturn(mockSpan);
+        when(mockPropagationCodec.encode(any())).thenReturn(Optional.of(EXPECTED_TRACE_HEADER));
+        final String expectedHttpMethod = "httpMethod1";
+        when(mockHttpRequest.getMethod()).thenReturn(expectedHttpMethod);
+
+        final Span span = httpClientPropagator.startPropagation(mockHttpRequest);
+
+        verify(span, times(2)).addField(anyString(), any());
+        verify(span).addField(TYPE_FIELD, HttpClientPropagator.HTTP_CLIENT_SPAN_TYPE);
+        verify(span).addField(CLIENT_REQUEST_METHOD_FIELD, expectedHttpMethod);
+        verify(mockHttpRequest).addHeader(HttpHeaderV1PropagationCodec.HONEYCOMB_TRACE_HEADER, EXPECTED_TRACE_HEADER);
+    }
+
+    @Test
+    public void whenStartPropagation_withAdditionalData_optionalSpanFieldsAreAdded_traceHeaderIsAdded() {
+        when(mockTracer.startChildSpan(EXPECTED_SPAN_NAME)).thenReturn(mockSpan);
+        when(mockPropagationCodec.encode(any())).thenReturn(Optional.of(EXPECTED_TRACE_HEADER));
+        final String expectedHttpMethod = "httpMethod1";
+        when(mockHttpRequest.getMethod()).thenReturn(expectedHttpMethod);
+        final String expectedPath = "expectedPath";
+        when(mockHttpRequest.getPath()).thenReturn(Optional.of(expectedPath));
+        final String expectedContentType = "expectedContentType";
+        when(mockHttpRequest.getFirstHeader(HttpHeaders.CONTENT_TYPE)).thenReturn(Optional.of(expectedContentType));
+        final int expectedContentLength = 1;
+        when(mockHttpRequest.getContentLength()).thenReturn(expectedContentLength);
+
+        final Span span = httpClientPropagator.startPropagation(mockHttpRequest);
+
+        verify(span, times(5)).addField(anyString(), any());
+        verify(span).addField(TYPE_FIELD, HttpClientPropagator.HTTP_CLIENT_SPAN_TYPE);
+        verify(span).addField(CLIENT_REQUEST_METHOD_FIELD, expectedHttpMethod);
+        verify(span).addField(CLIENT_REQUEST_CONTENT_TYPE_FIELD, expectedContentType);
+        verify(span).addField(CLIENT_REQUEST_CONTENT_LENGTH_FIELD, expectedContentLength);
+        verify(span).addField(CLIENT_REQUEST_PATH_FIELD, expectedPath);
+        verify(mockHttpRequest).addHeader(HttpHeaderV1PropagationCodec.HONEYCOMB_TRACE_HEADER, EXPECTED_TRACE_HEADER);
+    }
+
+    @Test
+    public void whenStartPropagation_andTraceHeaderIsGeneratedFromContext_doNotAddTraceHeader() {
+        when(mockTracer.startChildSpan(EXPECTED_SPAN_NAME)).thenReturn(mockSpan);
+        when(mockPropagationCodec.encode(any())).thenReturn(Optional.empty());
+        final String expectedHttpMethod = "httpMethod1";
+        when(mockHttpRequest.getMethod()).thenReturn(expectedHttpMethod);
+
+        final Span span = httpClientPropagator.startPropagation(mockHttpRequest);
+
+        verify(span, times(2)).addField(anyString(), any());
+        verify(span).addField(TYPE_FIELD, HttpClientPropagator.HTTP_CLIENT_SPAN_TYPE);
+        verify(span).addField(CLIENT_REQUEST_METHOD_FIELD, expectedHttpMethod);
+        verify(mockHttpRequest, never()).addHeader(HttpHeaderV1PropagationCodec.HONEYCOMB_TRACE_HEADER, EXPECTED_TRACE_HEADER);
+    }
+
+    @Test
+    public void whenEndPropagation_withNonNullResponse_thenOnlyAddRequiredResponseFields_andCloseSpan() {
+        final int expectedHttpStatus = 200;
+        when(mockHttpResponse.getStatus()).thenReturn(expectedHttpStatus);
+
+        httpClientPropagator.endPropagation(mockHttpResponse, null, mockSpan);
+
+        verify(mockSpan, times(1)).addField(anyString(), any());
+        verify(mockSpan).addField(CLIENT_RESPONSE_STATUS_CODE_FIELD, expectedHttpStatus);
+
+        verify(mockSpan).close();
+    }
+
+    @Test
+    public void whenEndPropagation_withNonNullError_thenOnlyAddErrorFields_andCloseSpan() {
+        final String expectedMessage = "expectedMessage";
+        final TestException throwable = new TestException(expectedMessage);
+
+        httpClientPropagator.endPropagation(null, throwable, mockSpan);
+
+        verify(mockSpan, times(2)).addField(anyString(), any());
+        verify(mockSpan).addField(CLIENT_REQUEST_ERROR_FIELD,"TestException");
+        verify(mockSpan).addField(CLIENT_REQUEST_ERROR_DETAIL_FIELD, expectedMessage);
+        verify(mockSpan).close();
+    }
+
+    private class TestException extends Exception {
+        public TestException(String message) {
+            super(message);
+        }
+    }
+}

--- a/beeline-core/src/test/java/io/honeycomb/beeline/tracing/propagation/HttpServerPropagatorTest.java
+++ b/beeline-core/src/test/java/io/honeycomb/beeline/tracing/propagation/HttpServerPropagatorTest.java
@@ -1,0 +1,134 @@
+package io.honeycomb.beeline.tracing.propagation;
+ 
+import io.honeycomb.beeline.tracing.Span;
+import io.honeycomb.libhoney.shaded.org.apache.http.HttpHeaders;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.Mock;
+import org.mockito.junit.MockitoJUnitRunner;
+
+import java.util.Optional;
+import java.util.function.Function;
+
+import static io.honeycomb.beeline.tracing.propagation.MockSpanUtils.stubFluentCalls;
+import static io.honeycomb.beeline.tracing.utils.TraceFieldConstants.*;
+import static org.mockito.Mockito.*;
+
+@RunWith(MockitoJUnitRunner.class)
+public class HttpServerPropagatorTest {
+    @Mock
+    private Span mockSpan;
+    @Mock
+    private HttpServerRequestAdapter mockHttpRequest;
+    @Mock
+    private HttpServerResponseAdapter mockHttpResponse;
+    @Mock
+    private HttpServerRequestSpanCustomizer mockSpanCustomizer;
+    @Mock
+    private PropagationCodec<String> mockPropagationCodec;
+    @Mock
+    private HttpServerPropagator.TraceStarter mockTraceStarter;
+    @Mock
+    private PropagationContext mockPropagationContext;
+
+    private HttpServerPropagator httpServerPropagator;
+
+    private static final String EXPECTED_SERVICE_NAME = "expectedServiceName";
+    private static final String EXPECTED_SPAN_NAME = "expectedSpanName";
+    private static final Function<HttpServerRequestAdapter, String> REQUEST_TO_SPAN_NAME = r -> EXPECTED_SPAN_NAME;
+
+    @Before
+    public void setup() {
+        stubFluentCalls(mockSpan);
+        httpServerPropagator = new HttpServerPropagator(EXPECTED_SERVICE_NAME, REQUEST_TO_SPAN_NAME,
+                                                        mockSpanCustomizer, mockPropagationCodec, mockTraceStarter);
+    }
+
+    @Test
+    public void whenStartPropagation_traceIsStarted_andHttpFieldsAreApplied() {
+        final String expectedTraceHeader = "expectedTraceHeader";
+        when(mockHttpRequest.getFirstHeader(HttpHeaderV1PropagationCodec.HONEYCOMB_TRACE_HEADER)).thenReturn(Optional.of(expectedTraceHeader));
+        when(mockPropagationCodec.decode(expectedTraceHeader)).thenReturn(mockPropagationContext);
+        when(mockTraceStarter.startTrace(EXPECTED_SPAN_NAME, mockPropagationContext, EXPECTED_SERVICE_NAME)).thenReturn(mockSpan);
+
+        final Span span = httpServerPropagator.startPropagation(mockHttpRequest);
+        verify(mockSpanCustomizer).customize(span, mockHttpRequest);
+    }
+
+    @Test
+    public void whenStartPropagation_andNoTraceHeaderIsPresent_traceIsStarted_andHttpFieldsAreApplied() {
+        when(mockPropagationCodec.decode(null)).thenReturn(mockPropagationContext);
+        when(mockTraceStarter.startTrace(EXPECTED_SPAN_NAME, mockPropagationContext, EXPECTED_SERVICE_NAME)).thenReturn(mockSpan);
+
+        final Span span = httpServerPropagator.startPropagation(mockHttpRequest);
+        verify(mockSpanCustomizer).customize(span, mockHttpRequest);
+    }
+
+    @Test
+    public void whenEndPropagation_andOnlyErrorIsPresent_thenAddErrorFields() {
+        final String expectedErrorMessage = "expectedErrorMessage";
+        final TestException error = new TestException(expectedErrorMessage);
+
+        httpServerPropagator.endPropagation(null, error, mockSpan);
+
+        verify(mockSpan, times(2)).addField(anyString(), any());
+        verify(mockSpan).addField(REQUEST_ERROR_FIELD, "TestException");
+        verify(mockSpan).addField(REQUEST_ERROR_DETAIL_FIELD, expectedErrorMessage);
+
+        verify(mockSpan).close();
+    }
+
+    @Test
+    public void whenEndPropagation_andOnlyErrorIsPresent_withoutErrorMessage_doNotAddErrorMessageField() {
+        final TestException error = new TestException();
+
+        httpServerPropagator.endPropagation(null, error, mockSpan);
+
+        verify(mockSpan).addField(anyString(), any());
+        verify(mockSpan).addField(REQUEST_ERROR_FIELD, "TestException");
+
+        verify(mockSpan).close();
+    }
+
+
+    @Test
+    public void whenEndPropagation_andResponseIsPresent_thenAddRequiredResponseFields() {
+        final int expectedStatus = 200;
+        when(mockHttpResponse.getStatus()).thenReturn(expectedStatus);
+
+        httpServerPropagator.endPropagation(mockHttpResponse, null, mockSpan);
+
+        verify(mockSpan).addField(anyString(), any());
+        verify(mockSpan).addField(STATUS_CODE_FIELD, expectedStatus);
+
+        verify(mockSpan).close();
+    }
+
+    @Test
+    public void whenEndPropagation_andResponseIsPresent_withContentType_thenAddAdditionalResponseFields() {
+        final int expectedStatus = 200;
+        when(mockHttpResponse.getStatus()).thenReturn(expectedStatus);
+        final String expectedContentType = "expectedContentType";
+        when(mockHttpResponse.getFirstHeader(HttpHeaders.CONTENT_TYPE)).thenReturn(Optional.of(expectedContentType));
+
+        httpServerPropagator.endPropagation(mockHttpResponse, null, mockSpan);
+
+        verify(mockSpan, times(2)).addField(anyString(), any());
+        verify(mockSpan).addField(STATUS_CODE_FIELD, expectedStatus);
+        verify(mockSpan).addField(RESPONSE_CONTENT_TYPE_FIELD, expectedContentType);
+
+        verify(mockSpan).close();
+    }
+
+
+    private static class TestException extends Exception {
+        public TestException(String message) {
+            super(message);
+        }
+
+        public TestException() {
+            //nothing
+        }
+    }
+}

--- a/beeline-core/src/test/java/io/honeycomb/beeline/tracing/propagation/HttpServerPropagatorTest.java
+++ b/beeline-core/src/test/java/io/honeycomb/beeline/tracing/propagation/HttpServerPropagatorTest.java
@@ -1,5 +1,6 @@
 package io.honeycomb.beeline.tracing.propagation;
  
+import io.honeycomb.beeline.tracing.Beeline;
 import io.honeycomb.beeline.tracing.Span;
 import io.honeycomb.libhoney.shaded.org.apache.http.HttpHeaders;
 import org.junit.Before;
@@ -28,7 +29,7 @@ public class HttpServerPropagatorTest {
     @Mock
     private PropagationCodec<String> mockPropagationCodec;
     @Mock
-    private HttpServerPropagator.TraceStarter mockTraceStarter;
+    private Beeline mockBeeline;
     @Mock
     private PropagationContext mockPropagationContext;
 
@@ -42,7 +43,7 @@ public class HttpServerPropagatorTest {
     public void setup() {
         stubFluentCalls(mockSpan);
         httpServerPropagator = new HttpServerPropagator(EXPECTED_SERVICE_NAME, REQUEST_TO_SPAN_NAME,
-                                                        mockSpanCustomizer, mockPropagationCodec, mockTraceStarter);
+                                                        mockSpanCustomizer, mockPropagationCodec, mockBeeline);
     }
 
     @Test
@@ -50,7 +51,7 @@ public class HttpServerPropagatorTest {
         final String expectedTraceHeader = "expectedTraceHeader";
         when(mockHttpRequest.getFirstHeader(HttpHeaderV1PropagationCodec.HONEYCOMB_TRACE_HEADER)).thenReturn(Optional.of(expectedTraceHeader));
         when(mockPropagationCodec.decode(expectedTraceHeader)).thenReturn(mockPropagationContext);
-        when(mockTraceStarter.startTrace(EXPECTED_SPAN_NAME, mockPropagationContext, EXPECTED_SERVICE_NAME)).thenReturn(mockSpan);
+        when(mockBeeline.startTrace(EXPECTED_SPAN_NAME, mockPropagationContext, EXPECTED_SERVICE_NAME)).thenReturn(mockSpan);
 
         final Span span = httpServerPropagator.startPropagation(mockHttpRequest);
         verify(mockSpanCustomizer).customize(span, mockHttpRequest);
@@ -59,7 +60,7 @@ public class HttpServerPropagatorTest {
     @Test
     public void whenStartPropagation_andNoTraceHeaderIsPresent_traceIsStarted_andHttpFieldsAreApplied() {
         when(mockPropagationCodec.decode(null)).thenReturn(mockPropagationContext);
-        when(mockTraceStarter.startTrace(EXPECTED_SPAN_NAME, mockPropagationContext, EXPECTED_SERVICE_NAME)).thenReturn(mockSpan);
+        when(mockBeeline.startTrace(EXPECTED_SPAN_NAME, mockPropagationContext, EXPECTED_SERVICE_NAME)).thenReturn(mockSpan);
 
         final Span span = httpServerPropagator.startPropagation(mockHttpRequest);
         verify(mockSpanCustomizer).customize(span, mockHttpRequest);

--- a/beeline-core/src/test/java/io/honeycomb/beeline/tracing/propagation/HttpServerRequestCustomizerTest.java
+++ b/beeline-core/src/test/java/io/honeycomb/beeline/tracing/propagation/HttpServerRequestCustomizerTest.java
@@ -1,0 +1,119 @@
+package io.honeycomb.beeline.tracing.propagation;
+
+import io.honeycomb.beeline.tracing.Span;
+import io.honeycomb.libhoney.shaded.org.apache.http.HttpHeaders;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.Mock;
+import org.mockito.junit.MockitoJUnitRunner;
+
+import java.util.*;
+
+import static io.honeycomb.beeline.tracing.propagation.MockSpanUtils.stubFluentCalls;
+import static io.honeycomb.beeline.tracing.utils.TraceFieldConstants.*;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.*;
+
+@RunWith(MockitoJUnitRunner.class)
+public class HttpServerRequestCustomizerTest {
+
+    private static final String EXPECTED_PROTOCOL = "expectedProtocol";
+    private final String EXPECTED_METHOD = "expectedMethod";
+    private final String EXPECTED_REMOTE_ADDRESS = "expectedRemoteAddress";
+
+    @Mock
+    private HttpServerRequestAdapter mockHttpRequest;
+    @Mock
+    private Span mockSpan;
+
+    private HttpServerRequestSpanCustomizer httpServerRequestSpanCustomizer;
+
+    @Before
+    public void setup() {
+        stubFluentCalls(mockSpan);
+        httpServerRequestSpanCustomizer = new HttpServerRequestSpanCustomizer();
+    }
+
+    @Test
+    public void testOnlyRequiredSpanFieldsAreAdded() {
+        stubRequiredRequestData(mockHttpRequest);
+
+        httpServerRequestSpanCustomizer.customize(mockSpan, mockHttpRequest);
+
+        verify(mockSpan, times(6)).addField(anyString(), any());
+        verifyRequiredSpanData(mockSpan, true);
+    }
+
+    @Test
+    public void testOptionalSpanFieldsAreAddedWhenDataIsPresent() {
+        final String expectedContentType = "expectedContentType";
+        final String expectedAccept = "expectedAccept";
+        final String expectedUserAgent = "expectedUserAgent";
+        final String expectedFP = "expectedXFP";
+        final String expectedXFF = "expectedXFF";
+        final String expectedHost = "expectedHost";
+        final String expectedPath = "expectedPath";
+        final String expectedScheme = "expectedScheme";
+        final Map<String, List<String>> expectedQueryParams = new HashMap<>();
+        final List<String> queryParamValues = Collections.singletonList("a value");
+        expectedQueryParams.put("param1", queryParamValues);
+        final int expectedContentLength = 10;
+        when(mockHttpRequest.getFirstHeader(HttpHeaders.CONTENT_TYPE)).thenReturn(Optional.of(expectedContentType));
+        when(mockHttpRequest.getFirstHeader(HttpHeaders.ACCEPT)).thenReturn(Optional.of(expectedAccept));
+        when(mockHttpRequest.getFirstHeader(HttpHeaders.USER_AGENT)).thenReturn(Optional.of(expectedUserAgent));
+        when(mockHttpRequest.getFirstHeader("x-forwarded-proto")).thenReturn(Optional.of(expectedFP));
+        when(mockHttpRequest.getFirstHeader("x-forwarded-for")).thenReturn(Optional.of(expectedXFF));
+        when(mockHttpRequest.getHost()).thenReturn(Optional.of(expectedHost));
+        when(mockHttpRequest.getPath()).thenReturn(Optional.of(expectedPath));
+        when(mockHttpRequest.getScheme()).thenReturn(Optional.of(expectedScheme));
+        when(mockHttpRequest.getQueryParams()).thenReturn(expectedQueryParams);
+        when(mockHttpRequest.getContentLength()).thenReturn(expectedContentLength);
+
+        stubRequiredRequestData(mockHttpRequest);
+
+        httpServerRequestSpanCustomizer.customize(mockSpan, mockHttpRequest);
+
+        verify(mockSpan, times(16)).addField(anyString(), any());
+        verifyRequiredSpanData(mockSpan, true);
+        verify(mockSpan).addField(REQUEST_CONTENT_LENGTH_FIELD, expectedContentLength);
+        verify(mockSpan).addField(REQUEST_CONTENT_TYPE_FIELD, expectedContentType);
+        verify(mockSpan).addField(REQUEST_ACCEPT_FIELD, expectedAccept);
+        verify(mockSpan).addField(USER_AGENT_FIELD, expectedUserAgent);
+        verify(mockSpan).addField(FORWARD_FOR_HEADER_FIELD, expectedXFF);
+        verify(mockSpan).addField(FORWARD_PROTO_HEADER_FIELD, expectedFP);
+        verify(mockSpan).addField(REQUEST_HOST_FIELD, expectedHost);
+        verify(mockSpan).addField(REQUEST_PATH_FIELD, expectedPath);
+        verify(mockSpan).addField(REQUEST_SCHEME_FIELD, expectedScheme);
+        verify(mockSpan).addField(REQUEST_QUERY_PARAMS_FIELD, expectedQueryParams);
+    }
+
+    @Test
+    public void testNonAjaxXRequestWithHeader() {
+        stubRequiredRequestData(mockHttpRequest);
+        when(mockHttpRequest.getFirstHeader("x-requested-with")).thenReturn(Optional.of("NonAjax"));
+
+        httpServerRequestSpanCustomizer.customize(mockSpan, mockHttpRequest);
+
+        verify(mockSpan, times(6)).addField(anyString(), any());
+        verifyRequiredSpanData(mockSpan, false);
+    }
+
+    private void stubRequiredRequestData(final HttpServerRequestAdapter mockHttpRequest) {
+        when(mockHttpRequest.getMethod()).thenReturn(EXPECTED_METHOD);
+        when(mockHttpRequest.getHttpVersion()).thenReturn(EXPECTED_PROTOCOL);
+        when(mockHttpRequest.isSecure()).thenReturn(true);
+        when(mockHttpRequest.getRemoteAddress()).thenReturn(EXPECTED_REMOTE_ADDRESS);
+        when(mockHttpRequest.getFirstHeader("x-requested-with")).thenReturn(Optional.of("XMLHttpRequest"));
+    }
+
+    private void verifyRequiredSpanData(final Span mockSpan, final boolean ajaxValue) {
+        verify(mockSpan).addField(TYPE_FIELD, HttpServerPropagator.OPERATION_TYPE_HTTP_SERVER);
+        verify(mockSpan).addField(REQUEST_METHOD_FIELD, EXPECTED_METHOD);
+        verify(mockSpan).addField(REQUEST_HTTP_VERSION_FIELD, EXPECTED_PROTOCOL);
+        verify(mockSpan).addField(REQUEST_SECURE_FIELD, true);
+        verify(mockSpan).addField(REQUEST_AJAX_FIELD, ajaxValue);
+        verify(mockSpan).addField(REQUEST_REMOTE_ADDRESS_FIELD, EXPECTED_REMOTE_ADDRESS);
+    }
+}

--- a/beeline-core/src/test/java/io/honeycomb/beeline/tracing/propagation/MockSpanUtils.java
+++ b/beeline-core/src/test/java/io/honeycomb/beeline/tracing/propagation/MockSpanUtils.java
@@ -1,0 +1,21 @@
+package io.honeycomb.beeline.tracing.propagation;
+ 
+import io.honeycomb.beeline.tracing.Span;
+
+import static org.mockito.ArgumentMatchers.*;
+import static org.mockito.ArgumentMatchers.anyLong;
+import static org.mockito.Mockito.lenient;
+
+public class MockSpanUtils {
+    /**
+     * To make the fluent API easier to use in the tests
+     */
+    public static void stubFluentCalls(final Span mockSpan) {
+        lenient().when(mockSpan.addField(anyString(), any())).thenReturn(mockSpan);
+        lenient().when(mockSpan.addFields(anyMap())).thenReturn(mockSpan);
+        lenient().when(mockSpan.addTraceField(anyString(), any())).thenReturn(mockSpan);
+        lenient().when(mockSpan.addTraceFields(anyMap())).thenReturn(mockSpan);
+        lenient().when(mockSpan.markStart()).thenReturn(mockSpan);
+        lenient().when(mockSpan.markStart(anyLong(), anyLong())).thenReturn(mockSpan);
+    }
+ }

--- a/beeline-core/src/test/resources/mockito-extensions/org.mockito.plugins.MockMaker
+++ b/beeline-core/src/test/resources/mockito-extensions/org.mockito.plugins.MockMaker
@@ -1,0 +1,1 @@
+mock-maker-inline

--- a/beeline-spring-boot-starter/pom.xml
+++ b/beeline-spring-boot-starter/pom.xml
@@ -16,7 +16,7 @@
     <description>Spring Boot Starter module to auto-configure Spring Boot with the Honeycomb Beeline for Java</description>
 
     <properties>
-        <beelineVersion>1.0.0</beelineVersion>
+        <beelineVersion>1.0.7</beelineVersion>
     </properties>
 
     <dependencies>

--- a/beeline-spring-boot-starter/src/main/java/io/honeycomb/beeline/spring/autoconfig/BeelineAutoconfig.java
+++ b/beeline-spring-boot-starter/src/main/java/io/honeycomb/beeline/spring/autoconfig/BeelineAutoconfig.java
@@ -1,10 +1,6 @@
 package io.honeycomb.beeline.spring.autoconfig;
 
-import io.honeycomb.beeline.spring.beans.BeelineHandlerInterceptor;
-import io.honeycomb.beeline.spring.beans.BeelineInstrumentation;
-import io.honeycomb.beeline.spring.beans.BeelineRestTemplateInterceptor;
-import io.honeycomb.beeline.spring.beans.BeelineServletFilter;
-import io.honeycomb.beeline.spring.beans.DebugResponseObserver;
+import io.honeycomb.beeline.spring.beans.*;
 import io.honeycomb.beeline.spring.beans.aspects.SpanAspect;
 import io.honeycomb.beeline.tracing.Beeline;
 import io.honeycomb.beeline.tracing.Span;
@@ -133,12 +129,10 @@ public class BeelineAutoconfig implements WebMvcConfigurer {
     @Bean
     @ConditionalOnMissingBean
     public BeelineServletFilter defaultBeelineFilter(final BeelineProperties beelineProperties,
-                                                     final Tracer tracer,
-                                                     final SpanBuilderFactory factory) {
+                                                     final Beeline beeline) {
         return new BeelineServletFilter(
             beelineProperties,
-            tracer,
-            factory,
+            beeline,
             beelineProperties.getIncludePathPatterns(),
             beelineProperties.getExcludePathPatterns()
         );

--- a/beeline-spring-boot-starter/src/main/java/io/honeycomb/beeline/spring/utils/InstrumentationConstants.java
+++ b/beeline-spring-boot-starter/src/main/java/io/honeycomb/beeline/spring/utils/InstrumentationConstants.java
@@ -10,7 +10,7 @@ public final class InstrumentationConstants {
 
     // @formatter:off
     // ========= Instrumentation constants =========
-    /** Value given to the type field in the webmvc instrumentation. */
+    /** @deprecated Use {@link io.honeycomb.beeline.tracing.propagation.HttpServerPropagator#OPERATION_TYPE_HTTP_SERVER}*/
     public static final String OPERATION_TYPE_HTTP_SERVER       = "http_server";
     /** Prefix added to span names generated in the webmvc filter. */
     public static final String FILTER_SPAN_NAME_PREFIX          = "http_";
@@ -22,7 +22,7 @@ public final class InstrumentationConstants {
     public static final String AOP_INSTRUMENTATION_NAME           = "spring_aop";
     /** Name of the http client span created by the rest template instrumentation. */
     public static final String HTTP_CLIENT_SPAN_NAME            = "http_client_request";
-    /** Value given to the type field in the rest template instrumentation. */
+    /** @deprecated Use {@link io.honeycomb.beeline.tracing.propagation.HttpClientPropagator#HTTP_CLIENT_SPAN_TYPE} */
     public static final String HTTP_CLIENT_SPAN_TYPE            = "http_client";
     /** Value given to the type field in the annotation-drive instrumentation. */
     public static final String ANNOTATED_METHOD_TYPE            = "annotated_method";

--- a/beeline-spring-boot-starter/src/main/java/io/honeycomb/beeline/spring/utils/MoreTraceFieldConstants.java
+++ b/beeline-spring-boot-starter/src/main/java/io/honeycomb/beeline/spring/utils/MoreTraceFieldConstants.java
@@ -1,6 +1,7 @@
 package io.honeycomb.beeline.spring.utils;
 
 import io.honeycomb.beeline.tracing.utils.TraceFieldConstants;
+import org.springframework.http.client.ClientHttpResponse;
 
 /**
  * Class to keep the names of fields not (yet) defined in the Beeline specs or ones that are spring/java-specific.
@@ -21,33 +22,33 @@ public final class MoreTraceFieldConstants {
     public static final String JOIN_POINT_RESULT_FIELD       = "spring.method.result";
 
     // ========= http client fields =========
-    /** */
+    /** @deprecated Use {@link io.honeycomb.beeline.tracing.utils.TraceFieldConstants#CLIENT_REQUEST_PATH_FIELD} */
     public static final String CLIENT_REQUEST_PATH_FIELD            = "client.request.path";
-    /** */
+    /** @deprecated Use {@link io.honeycomb.beeline.tracing.utils.TraceFieldConstants#CLIENT_REQUEST_METHOD_FIELD} */
     public static final String CLIENT_REQUEST_METHOD_FIELD          = "client.request.method";
-    /** */
+    /** @deprecated Use {@link io.honeycomb.beeline.tracing.utils.TraceFieldConstants#CLIENT_REQUEST_CONTENT_LENGTH_FIELD} */
     public static final String CLIENT_REQUEST_CONTENT_LENGTH_FIELD  = "client.request.content_length";
-    /** */
+    /** @deprecated Use {@link io.honeycomb.beeline.tracing.utils.TraceFieldConstants#CLIENT_REQUEST_CONTENT_TYPE_FIELD} */
     public static final String CLIENT_REQUEST_CONTENT_TYPE_FIELD    = "client.request.content_type";
-    /** */
+    /** @deprecated Use {@link io.honeycomb.beeline.tracing.utils.TraceFieldConstants#CLIENT_REQUEST_ERROR_FIELD} */
     public static final String CLIENT_REQUEST_ERROR_FIELD           = "client.request.error";
-    /** */
+    /** @deprecated Use {@link io.honeycomb.beeline.tracing.utils.TraceFieldConstants#CLIENT_REQUEST_ERROR_DETAIL_FIELD} */
     public static final String CLIENT_REQUEST_ERROR_DETAIL_FIELD    = "client.request.error_detail";
-    /** */
+    /** @deprecated Use {@link io.honeycomb.beeline.tracing.utils.TraceFieldConstants#CLIENT_RESPONSE_CONTENT_TYPE_FIELD} */
     public static final String CLIENT_RESPONSE_CONTENT_TYPE_FIELD   = "client.response.content_type";
-    /** */
+    /** @deprecated Use {@link io.honeycomb.beeline.tracing.utils.TraceFieldConstants#CLIENT_RESPONSE_STATUS_CODE_FIELD} */
     public static final String CLIENT_RESPONSE_STATUS_CODE_FIELD    = "client.response.status_code";
-    /** */
+    /** @deprecated Use {@link io.honeycomb.beeline.tracing.utils.TraceFieldConstants#CLIENT_RESPONSE_CONTENT_LENGTH} */
     public static final String CLIENT_RESPONSE_CONTENT_LENGTH       = "client.response.content_length";
 
     // ========= request fields =========
-    /** The response content type - if available. */
+    /** @deprecated Use {@link io.honeycomb.beeline.tracing.utils.TraceFieldConstants#RESPONSE_CONTENT_TYPE_FIELD} */
     public static final String RESPONSE_CONTENT_TYPE_FIELD  = "response.header.content_type";
-    /** The request content type - if available. */
+    /** @deprecated Use {@link io.honeycomb.beeline.tracing.utils.TraceFieldConstants#REQUEST_CONTENT_TYPE_FIELD} */
     public static final String REQUEST_CONTENT_TYPE_FIELD   = "request.header.content_type";
-    /** The request accept header - if available. */
+    /** @deprecated Use {@link io.honeycomb.beeline.tracing.utils.TraceFieldConstants#REQUEST_ACCEPT_FIELD} */
     public static final String REQUEST_ACCEPT_FIELD         = "request.header.accept";
-    /** Any query parameters on the request URL. */
+    /** @deprecated Use {@link io.honeycomb.beeline.tracing.utils.TraceFieldConstants#REQUEST_QUERY_PARAMS_FIELD} */
     public static final String REQUEST_QUERY_PARAMS_FIELD   = "request.query";
 
     // ========= spring-specific fields =========
@@ -61,6 +62,22 @@ public final class MoreTraceFieldConstants {
     public static final String SPRING_HANDLER_METHOD_FIELD  = "spring.request.handler_method";
     /** The URI pattern that was matched for the given request. */
     public static final String SPRING_MATCHED_PATTERN_FIELD = "spring.request.matched_pattern";
+    /**
+     * Spring may throw an exception when the {@link io.honeycomb.beeline.spring.beans.BeelineRestTemplateInterceptor}
+     * calls {@link ClientHttpResponse#getRawStatusCode()}. This exception is not propagated to the caller by the
+     * instrumentation.
+     * <p>
+     * This field shows the type of exception that was thrown.
+     */
+    public static final String REST_TEMPLATE_RESPONSE_STATUS_ERROR_FIELD = "spring.rest_template.status_error";
+    /**
+     * Spring may throw an exception when the {@link io.honeycomb.beeline.spring.beans.BeelineRestTemplateInterceptor}
+     * calls {@link ClientHttpResponse#getRawStatusCode()}. This exception is not propagated to the caller by the
+     * instrumentation.
+     * <p>
+     * This field show the any exception message.
+     */
+    public static final String REST_TEMPLATE_RESPONSE_STATUS_ERROR_DETAIL_FIELD = "spring.rest_template.status_error_detail";
     // @formatter:on
 
     private MoreTraceFieldConstants() {

--- a/beeline-spring-boot-starter/src/test/java/io/honeycomb/beeline/spring/mockmvctests/MockMvcTest.java
+++ b/beeline-spring-boot-starter/src/test/java/io/honeycomb/beeline/spring/mockmvctests/MockMvcTest.java
@@ -314,7 +314,7 @@ public class MockMvcTest {
         checkMetaFields(eventFields);
         assertThat(eventFields).containsEntry("name", "BasicPost");
         assertThat(eventFields).containsEntry("request.header.content_type", "text/plain");
-        assertThat(eventFields).containsEntry("request.content_length", 5L);
+        assertThat(eventFields).containsEntry("request.content_length", 5);
         assertThat(eventFields).containsEntry("response.status_code", 200);
         assertThat(eventFields).doesNotContainKeys(problemFields);
     }

--- a/pom.xml
+++ b/pom.xml
@@ -75,7 +75,7 @@
 
         <!-- TEST dependency versions  -->
         <junitVersion>4.12</junitVersion>
-        <mockitoVersion>2.18.0</mockitoVersion>
+        <mockitoVersion>3.1.0</mockitoVersion>
         <assertjVersion>3.11.1</assertjVersion>
         <wiremockVersion>2.21.0</wiremockVersion>
         <restAssuredVersion>3.3.0</restAssuredVersion>
@@ -268,10 +268,10 @@
                 <configuration>
                     <archive>
                         <manifest>
-                           
+
                             <!-- Add implementation/specification version to manifest file so we can read it out at runtime
                             (e.g. [class].class.getPackage().getImplementationVersion()) -->
-                            
+
                             <addDefaultImplementationEntries>true</addDefaultImplementationEntries>
                             <addDefaultSpecificationEntries>true</addDefaultSpecificationEntries>
                         </manifest>


### PR DESCRIPTION
# Changes:
- Added high-level utilities to make manual instrumentation of HTTP client/server easier.
- Refactored the Spring starter's ServletFilter and RestTemplate Interceptor to use these.
- Deprecated constants in the Spring starter and moved them to Core where appropriate.
- Configured Mockito to allow mocks on final classes.
- Fixed a versioning issue in the parent POM: the POM was referencing an old version of Core.

# Notes for reviewers
Below are some points that are worth pointing out:
1. AFAIK, when we were creating the Spring HTTP instrumentation, Honeycomb said that the span names generated by this should be low cardinality. As such, the span name generated by the [BeelineRestTemplateInterceptor](https://github.com/wtce/beeline-java/blob/http-trace-propagation-utilities/beeline-spring-boot-starter/src/main/java/io/honeycomb/beeline/spring/beans/BeelineRestTemplateInterceptor.java) was a constant and the span names generated by the [BeelineServletFilter](https://github.com/wtce/beeline-java/blob/http-trace-propagation-utilities/beeline-spring-boot-starter/src/main/java/io/honeycomb/beeline/spring/beans/BeelineServletFilter.java) were a constant concatenated with the name of the HTTP method being called. For the changes in this PR, I made this low cardinality assumption clear in the documentation. See the constructors of the [HttpClientPropagator](https://github.com/wtce/beeline-java/blob/http-trace-propagation-utilities/beeline-core/src/main/java/io/honeycomb/beeline/tracing/propagation/HttpClientPropagator.java) and the [HttpServerPropagator](https://github.com/wtce/beeline-java/blob/http-trace-propagation-utilities/beeline-core/src/main/java/io/honeycomb/beeline/tracing/propagation/HttpServerPropagator.java). Please can reviewers verify that the assumption and wording in the documentation is correct.
2. If you compare the documentation at the top of [TraceFieldConstants](https://github.com/wtce/beeline-java/blob/http-trace-propagation-utilities/beeline-core/src/main/java/io/honeycomb/beeline/tracing/utils/TraceFieldConstants.java) with the documentation at the top of [MoreTraceFieldConstants](https://github.com/wtce/beeline-java/blob/http-trace-propagation-utilities/beeline-spring-boot-starter/src/main/java/io/honeycomb/beeline/spring/utils/MoreTraceFieldConstants.java), it implies that the former contains span fields names that are in the Honeycomb spec and the latter contains span fields name that are not yet. In moving the HTTP instrumentation into `beeline-core` from `beeline-spring-boot-starter` I moved constants from the "non-spec" file to the "spec" file. I am not sure what the current fields in the Honeycomb spec are today, so could you verify that this is desired for each of these constants.
3. I changed the functionality of the BeelineRestTemplateInterceptor slightly. It used to throw an exception if a call to `org.springframework.http.client.ClientHttpResponse#getRawStatusCode`
threw an IOException. I took the decision to say that this should be swallowed at the level of the instrumentation to ensure: (1) we don't have checked exceptions in the 
[HttpClientResponseAdapter](https://github.com/wtce/beeline-java/blob/http-trace-propagation-utilities/beeline-core/src/main/java/io/honeycomb/beeline/tracing/propagation/HttpClientResponseAdapter.java) interface for clients to deal with, and (2) we don't break the rule against having the instrumentation throw exceptions up to the non-instrumentation layer. I've added two Spring-specific span fields for noting that this edge case occurred. Please verify that this behaviour is desired.
4. I think having the original [Beeline](https://github.com/wtce/beeline-java/blob/http-trace-propagation-utilities/beeline-core/src/main/java/io/honeycomb/beeline/tracing/Beeline.java) class and the new [DefaultBeeline](https://github.com/wtce/beeline-java/blob/http-trace-propagation-utilities/beeline-core/src/main/java/io/honeycomb/beeline/DefaultBeeline.java) might be a bit confusing for some clients. The documentation on the Beeline seems to imply it is a place for convenience methods, e.g:
    ```
     * However, access to the low level API is given via the delegates returned by {@link #getTracer()} and
     * {@link #getSpanBuilderFactory()}. The Beeline class is essentially a façade to those delegates,
     * narrowing and bundling lower-level APIs to target the most common use-cases.
    ```
    But the documentation on the DefaultBeeline also suggests it is a place for convenience methods.  However, if we put convenience methods on the DefaultBeeline (as have been added), those methods can't be used if you only have a reference to the Beeline. And if you use the DefaultBeeline, you have to use a bunch of default settings.

    I wanted to add a convenience method (see `TraceStarter#startTrace` inside
[HttpServerPropagator](https://github.com/wtce/beeline-java/blob/http-trace-propagation-utilities/beeline-core/src/main/java/io/honeycomb/beeline/tracing/propagation/HttpServerPropagator.java#L126)) but putting it on either the Beeline or DefaultBeeline would create problems at this point, so I put it in a place which did not change the public API. I suggest we discuss what is the best approach to addressing this, and if any change is required we should put it in a different PR.