### PR TITLE
remove endTrace from DefaultBeeline.close() method as it is misleading

### DIFF
--- a/beeline-core/src/main/java/io/honeycomb/beeline/DefaultBeeline.java
+++ b/beeline-core/src/main/java/io/honeycomb/beeline/DefaultBeeline.java
@@ -144,14 +144,13 @@ public class DefaultBeeline {
     }
     
     /**
-     * endTrace ends the currently active trace.
+     * endTrace ends the currently active trace on the thread it is called from
      */
     public void endTrace() {
         this.tracer.endTrace();
     }
 
     public void close() {
-        this.tracer.endTrace();
         this.client.close();
     }
 }


### PR DESCRIPTION
Resolves #19: The call to `tracer.endTrace()` within `DefaultBeeline.close()` was misleading because it will only end the trace local to the thread that called `DefaultBeeline.close()`, instead of closing all traces.
