### PR TITLE
Add TracingContext interface to enable other ways to hold spans for a request

### DIFF
--- a/beeline-core/src/main/java/io/honeycomb/beeline/tracing/SendingSpan.java
+++ b/beeline-core/src/main/java/io/honeycomb/beeline/tracing/SendingSpan.java
@@ -85,4 +85,5 @@ public class SendingSpan extends Span {
     protected SpanPostProcessor getProcessor() {
         return processor;
     }
+
 }

--- a/beeline-core/src/main/java/io/honeycomb/beeline/tracing/Span.java
+++ b/beeline-core/src/main/java/io/honeycomb/beeline/tracing/Span.java
@@ -368,17 +368,17 @@ public class Span implements AutoCloseable {
 
     @Override
     public String toString() {
-        return "Span{" +
-               "noop=" + noop +
-               ", spanName='" + spanName + '\'' +
-               ", serviceName='" + serviceName + '\'' +
-               ", parentSpanId='" + parentSpanId + '\'' +
-               ", traceId='" + traceId + '\'' +
-               ", spanId='" + spanId + '\'' +
-               ", traceFields=" + traceFields +
-               ", fields=" + fields +
+        return getClass().getSimpleName() + "{" +
+               "noop=" + isNoop() +
+               ", spanName='" + getSpanName() + '\'' +
+               ", serviceName='" + getServiceName() + '\'' +
+               ", parentSpanId='" + getParentSpanId() + '\'' +
+               ", traceId='" + getTraceId() + '\'' +
+               ", spanId='" + getSpanId() + '\'' +
+               ", traceFields=" + getTraceFields() +
+               ", fields=" + getFields() +
                ", clock=" + clock +
-               ", startTimestamp=" + startTimestamp +
+               ", startTimestamp=" + getStartTime() +
                ", startOfElapsedTime=" + startOfElapsedTime +
                ", closed=" + closed +
                '}';

--- a/beeline-core/src/main/java/io/honeycomb/beeline/tracing/TracerSpan.java
+++ b/beeline-core/src/main/java/io/honeycomb/beeline/tracing/TracerSpan.java
@@ -163,5 +163,11 @@ public class TracerSpan extends Span {
     protected void closeInternal() {
         delegate.close();
     }
+
+    @Override
+    public String toString()
+    {
+        return "TracerSpan{" + "delegate=" + delegate + '}';
+    }
 }
 

--- a/beeline-core/src/main/java/io/honeycomb/beeline/tracing/Tracing.java
+++ b/beeline-core/src/main/java/io/honeycomb/beeline/tracing/Tracing.java
@@ -3,6 +3,7 @@ package io.honeycomb.beeline.tracing;
 import io.honeycomb.beeline.tracing.ids.TraceIdProvider;
 import io.honeycomb.beeline.tracing.ids.UUIDTraceIdProvider;
 import io.honeycomb.beeline.tracing.sampling.TraceSampler;
+import io.honeycomb.beeline.tracing.context.TracingContext;
 import io.honeycomb.libhoney.HoneyClient;
 import io.honeycomb.libhoney.transport.batch.ClockProvider;
 import io.honeycomb.libhoney.transport.batch.impl.SystemClockProvider;
@@ -47,6 +48,19 @@ public final class Tracing {
      */
     public static Tracer createTracer(final SpanBuilderFactory factory) {
         return new Tracer(factory);
+    }
+
+    /**
+     * Factory method to create a new {@link Tracer} instance,
+     * which helps manage tracing instrumentation and reports spans to Honeycomb using the provided client.
+     * See the Tracer's javadoc for details.
+     *
+     * @param factory used to create Builders of Spans.
+     * @return an instance of Tracer.
+     * @see #createSpanBuilderFactory(SpanPostProcessor, TraceSampler)
+     */
+    public static Tracer createTracer(final SpanBuilderFactory factory, TracingContext context ) {
+        return new Tracer(factory, context);
     }
 
     /**

--- a/beeline-core/src/main/java/io/honeycomb/beeline/tracing/Tracing.java
+++ b/beeline-core/src/main/java/io/honeycomb/beeline/tracing/Tracing.java
@@ -56,6 +56,7 @@ public final class Tracing {
      * See the Tracer's javadoc for details.
      *
      * @param factory used to create Builders of Spans.
+     * @param context {@link TracingContext} instance to use to tracking spans associated with a request
      * @return an instance of Tracer.
      * @see #createSpanBuilderFactory(SpanPostProcessor, TraceSampler)
      */

--- a/beeline-core/src/main/java/io/honeycomb/beeline/tracing/context/ThreadLocalTracingContext.java
+++ b/beeline-core/src/main/java/io/honeycomb/beeline/tracing/context/ThreadLocalTracingContext.java
@@ -1,0 +1,67 @@
+package io.honeycomb.beeline.tracing.context;
+
+import io.honeycomb.beeline.tracing.TracerSpan;
+
+import java.util.ArrayDeque;
+import java.util.Deque;
+
+public class ThreadLocalTracingContext
+    implements TracingContext
+{
+    /*
+    Usually, thread-locals are made static to make data globally accessible to a thread in a thread-safe/efficient
+    manner (e.g. static calls into an MDC context).
+
+    However, Tracer maintains thread local state per thread & per instance. This is because all access to the class is
+    done non-statically and state is managed through the instance. While an unlikely situation, this makes it at least
+    possible for users to create multiple Tracer instances with different configurations (e.g. sending to different
+    data-sets) without the Tracers interfering with each other's thread-local context.
+    */
+    private final ThreadLocal<Deque<TracerSpan>> spanStack;
+
+    public ThreadLocalTracingContext(){
+        this.spanStack = ThreadLocal.withInitial( ArrayDeque::new);
+    }
+
+    @Override
+    public Deque<TracerSpan> get()
+    {
+        return spanStack.get();
+    }
+
+    @Override
+    public int size()
+    {
+        return spanStack.get().size();
+    }
+
+    @Override
+    public TracerSpan peekLast()
+    {
+        return spanStack.get().peekLast();
+    }
+
+    @Override
+    public TracerSpan peekFirst()
+    {
+        return spanStack.get().peekFirst();
+    }
+
+    @Override
+    public boolean isEmpty()
+    {
+        return spanStack.get().isEmpty();
+    }
+
+    @Override
+    public void push( final TracerSpan span )
+    {
+        spanStack.get().push( span );
+    }
+
+    @Override
+    public TracerSpan pop()
+    {
+        return spanStack.get().pop();
+    }
+}

--- a/beeline-core/src/main/java/io/honeycomb/beeline/tracing/context/ThreadLocalTracingContext.java
+++ b/beeline-core/src/main/java/io/honeycomb/beeline/tracing/context/ThreadLocalTracingContext.java
@@ -5,6 +5,12 @@ import io.honeycomb.beeline.tracing.TracerSpan;
 import java.util.ArrayDeque;
 import java.util.Deque;
 
+/**
+ * This {@link TracingContext} uses a non-static {@link ThreadLocal} to store the current tracing stack, which will work
+ * under ordinary circumstances to isolate spans associated with a single request from other concurrent requests. Using
+ * a non-static ThreadLocal allows for the possibility of having multiple {@link io.honeycomb.beeline.tracing.Tracer}
+ * instances working in the service at the same time, using the same threads, but working on different requests.
+ */
 public class ThreadLocalTracingContext
     implements TracingContext
 {

--- a/beeline-core/src/main/java/io/honeycomb/beeline/tracing/context/TracingContext.java
+++ b/beeline-core/src/main/java/io/honeycomb/beeline/tracing/context/TracingContext.java
@@ -1,0 +1,22 @@
+package io.honeycomb.beeline.tracing.context;
+
+import io.honeycomb.beeline.tracing.TracerSpan;
+
+import java.util.Deque;
+
+public interface TracingContext
+{
+    Deque<TracerSpan> get();
+
+    int size();
+
+    TracerSpan peekLast();
+
+    TracerSpan peekFirst();
+
+    boolean isEmpty();
+
+    void push( TracerSpan span );
+
+    TracerSpan pop();
+}

--- a/beeline-core/src/main/java/io/honeycomb/beeline/tracing/context/TracingContext.java
+++ b/beeline-core/src/main/java/io/honeycomb/beeline/tracing/context/TracingContext.java
@@ -4,19 +4,58 @@ import io.honeycomb.beeline.tracing.TracerSpan;
 
 import java.util.Deque;
 
+/**
+ * An interface that allows the user to configure how spans in a trace are collected by the
+ * {@link io.honeycomb.beeline.tracing.Tracer}.
+ * <p>
+ * In most cases, the {@link ThreadLocalTracingContext} will be preferrable, and indeed is the default when no special
+ * configuration is given. However, in certain cases (eg. when tracing inside a multi-threaded monolithic application),
+ * more complex span tracking may be needed in order to overcome {@link ThreadLocal} limitations with long-running
+ * thread pools.
+ *
+ * @see io.honeycomb.beeline.tracing.Tracer
+ */
 public interface TracingContext
 {
+    /**
+     * Return the stack of spans in the current trace (for this service).
+     * @return The current {@link Deque} of spans. <b>Never null.</b>
+     */
     Deque<TracerSpan> get();
 
+    /**
+     * The size of the current span stack
+     * @return int value, zero-to-positive
+     */
     int size();
 
+    /**
+     * Grab the founding Span in the current stack without removing it.
+     * @return The first Span in this service's trace.
+     */
     TracerSpan peekLast();
 
+    /**
+     * Grab the latest Span in the current stack without removing it.
+     * @return The first Span in this service's trace.
+     */
     TracerSpan peekFirst();
 
+    /**
+     * Check whether the current Span stack if empty.
+     * @return True if the stack is empty (or missing). False otherwise.
+     */
     boolean isEmpty();
 
+    /**
+     * Add a new Span to the current service-scope of the trace.
+     * @param span The span to add
+     */
     void push( TracerSpan span );
 
+    /**
+     * Pop the latest Span off the stack for the current service trace and return it.
+     * @return the popped value, in case it's useful for debugging, etc.
+     */
     TracerSpan pop();
 }


### PR DESCRIPTION
This allows us to be more flexible in how we track related spans, especially for systems that
use fixed-size thread pools that recycle threads (which can cause problems with ThreadLocals
because they can inherit incorrect contexts, etc).

Also, making some small adjustments to Span.toString() to allow it to report on actual
class / sub-class in use.