### PR TITLE
Added BeelineQueryListenerForJDBC to auto-instrument JDBC

### DIFF
--- a/beeline-core/src/main/java/io/honeycomb/beeline/tracing/utils/TraceFieldConstants.java
+++ b/beeline-core/src/main/java/io/honeycomb/beeline/tracing/utils/TraceFieldConstants.java
@@ -104,6 +104,24 @@ public final class TraceFieldConstants {
     /** The response content type - if available. */
     public static final String RESPONSE_CONTENT_TYPE_FIELD  = "response.header.content_type";
 
+    // ========= database namespace =========
+    /** The database query being run */
+    public static final String DATABASE_QUERY_FIELD = "db.query";
+    /** The database query parameters */
+    public static final String DATABASE_QUERY_PARAMETERS_FIELD = "db.query_params";
+    public static final String DATABASE_CONNECTION_ID_FIELD = "db.connection_id";
+    /** The size of database batch being executed */
+    public static final String DATABASE_BATCH_SIZE_FIELD = "db.batch_size";
+    /** Is the query part of a batch execution */
+    public static final String DATABASE_IS_BATCH_FIELD = "db.is_batch";
+    public static final String DATABASE_STATEMENT_TYPE_FIELD = "db.statement_type";
+    /** Whether database query was successful */
+    public static final String DATABASE_IS_SUCCESS = "db.is_success";
+    /** Name of an error encountered that caused the request to fail (e.g. the name of an exception). */
+    public static final String DATABASE_ERROR = "db.error";
+    /** Detail about the error (e.g. the exception's message). */
+    public static final String DATABASE_ERROR_DETAILS = "db.error_details";
+
     //// ========= indicators of problems =========
     /** A child span sent as result of its parent being closed before it was closed. */
     public static final String META_SENT_BY_PARENT_FIELD    = "meta.sent_by_parent";

--- a/beeline-spring-boot-starter/pom.xml
+++ b/beeline-spring-boot-starter/pom.xml
@@ -63,6 +63,12 @@
             <version>${springBootVersion}</version>
         </dependency>
 
+        <dependency>
+            <groupId>net.ttddyy</groupId>
+            <artifactId>datasource-proxy</artifactId>
+            <version>1.6</version>
+        </dependency>
+
         <!--Annotation processing -->
         <dependency>
             <groupId>org.springframework.boot</groupId>

--- a/beeline-spring-boot-starter/src/main/java/io/honeycomb/beeline/spring/autoconfig/BeelineAutoconfig.java
+++ b/beeline-spring-boot-starter/src/main/java/io/honeycomb/beeline/spring/autoconfig/BeelineAutoconfig.java
@@ -216,4 +216,10 @@ public class BeelineAutoconfig implements WebMvcConfigurer {
     public SpanAspect defaultBeelineSpanAspect(final Tracer tracer) {
         return new SpanAspect(tracer);
     }
+
+    @Bean
+    @ConditionalOnProperty(name = "honeycomb.beeline.jdbc.enabled", havingValue = "true", matchIfMissing = true)
+    public DataSourceProxyBeanPostProcessor proxyBeanPostProcessor(Beeline beeline){
+        return new DataSourceProxyBeanPostProcessor(beeline);
+    }
 }

--- a/beeline-spring-boot-starter/src/main/java/io/honeycomb/beeline/spring/autoconfig/BeelineAutoconfig.java
+++ b/beeline-spring-boot-starter/src/main/java/io/honeycomb/beeline/spring/autoconfig/BeelineAutoconfig.java
@@ -219,7 +219,13 @@ public class BeelineAutoconfig implements WebMvcConfigurer {
 
     @Bean
     @ConditionalOnProperty(name = "honeycomb.beeline.jdbc.enabled", havingValue = "true", matchIfMissing = true)
-    public DataSourceProxyBeanPostProcessor proxyBeanPostProcessor(Beeline beeline){
-        return new DataSourceProxyBeanPostProcessor(beeline);
+    public BeelineQueryListenerForJDBC beelineQueryListenerForJDBC(Beeline beeline){
+        return new BeelineQueryListenerForJDBC(beeline);
+    }
+
+    @Bean
+    @ConditionalOnProperty(name = "honeycomb.beeline.jdbc.enabled", havingValue = "true", matchIfMissing = true)
+    public DataSourceProxyBeanPostProcessor proxyBeanPostProcessor(BeelineQueryListenerForJDBC listener){
+        return new DataSourceProxyBeanPostProcessor(listener);
     }
 }

--- a/beeline-spring-boot-starter/src/main/java/io/honeycomb/beeline/spring/beans/BeelineQueryListenerForJDBC.java
+++ b/beeline-spring-boot-starter/src/main/java/io/honeycomb/beeline/spring/beans/BeelineQueryListenerForJDBC.java
@@ -1,0 +1,120 @@
+package io.honeycomb.beeline.spring.beans;
+
+import io.honeycomb.beeline.tracing.Beeline;
+import io.honeycomb.beeline.tracing.Span;
+import io.honeycomb.beeline.tracing.Tracer;
+import io.honeycomb.beeline.tracing.propagation.PropagationContext;
+import io.honeycomb.beeline.tracing.utils.TraceFieldConstants;
+import net.ttddyy.dsproxy.ExecutionInfo;
+import net.ttddyy.dsproxy.QueryInfo;
+import net.ttddyy.dsproxy.listener.QueryExecutionListener;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.util.ArrayList;
+import java.util.List;
+
+public class BeelineQueryListenerForJDBC implements QueryExecutionListener {
+    final static String CHILD_SPAN_KEY = "childSpans";
+    final static String ROOT_SPAN_KEY = "rootSpan";
+    private static final Logger LOG = LoggerFactory.getLogger(BeelineQueryListenerForJDBC.class);
+    private final static String BATCH_SPAN_NAME = "query_batch";
+    private final static String QUERY_SPAN_NAME = "query";
+    private final static String SERVICE_NAME = "query_listener";
+
+    private final Beeline beeline;
+
+    public BeelineQueryListenerForJDBC(final Beeline beeline) {
+        this.beeline = beeline;
+    }
+
+    @Override
+    public void beforeQuery(final ExecutionInfo execInfo, final List<QueryInfo> queryInfoList) {
+        final boolean hasActiveSpan = !beeline.getActiveSpan().isNoop();
+        final Span rootSpan = hasActiveSpan ? beeline.startTrace(BATCH_SPAN_NAME, PropagationContext.emptyContext(), SERVICE_NAME) : beeline.getActiveSpan();
+        final Tracer tracer = beeline.getTracer();
+        final List<Span> childSpans = new ArrayList<>();
+        queryInfoList.forEach(queryInfo -> {
+            final Span childSpan = tracer.startChildSpan(QUERY_SPAN_NAME);
+            childSpan.markStart();
+            childSpans.add(childSpan);
+        });
+        execInfo.addCustomValue(CHILD_SPAN_KEY, childSpans);
+        execInfo.addCustomValue(ROOT_SPAN_KEY, rootSpan);
+    }
+
+    @Override
+    public void afterQuery(final ExecutionInfo execInfo, final List<QueryInfo> queryInfoList) {
+        final Span rootSpan = safelyValidateRootSpan(execInfo);
+        final List<Span> childSpans = safelyValidateChildSpans(execInfo);
+        if (rootSpan == null) {
+            LOG.error("Root span not found");
+            return;
+        }
+        if (childSpans == null) {
+            rootSpan.close();
+            LOG.error("Child spans not found");
+            return;
+        }
+        if (childSpans.size() != queryInfoList.size()) {
+            LOG.warn("Expected Child spans to match queries childSpans={} queries={}", childSpans.size(), queryInfoList.size());
+        }
+
+        final int length = Math.min(childSpans.size(), queryInfoList.size());
+        for (int i = 0; i < length; i++) {
+            final Object o = childSpans.get(i);
+            final Class<?> oClass = o.getClass();
+            if (!Span.class.isAssignableFrom(oClass)) {
+                LOG.warn("Expected span type but got class {}", oClass);
+                continue;
+            }
+            try (Span span = (Span) o) {
+                final QueryInfo info = queryInfoList.get(i);
+                applyToSpan(execInfo, info, span);
+            }
+        }
+        rootSpan.close();
+    }
+
+    private Span safelyValidateRootSpan(ExecutionInfo executionInfo) {
+        try {
+            return executionInfo.getCustomValue(ROOT_SPAN_KEY, Span.class);
+        } catch (ClassCastException e) {
+            LOG.error("Root span invalid type");
+        }
+        return null;
+    }
+
+    @SuppressWarnings("unchecked")
+    private List<Span> safelyValidateChildSpans(ExecutionInfo executionInfo) {
+        try {
+            return executionInfo.getCustomValue(CHILD_SPAN_KEY, List.class);
+
+        } catch (ClassCastException e) {
+            LOG.error("Child span invalid type");
+        }
+        return null;
+    }
+
+    private void applyToSpan(final ExecutionInfo execInfo, final QueryInfo queryInfo, final Span span) {
+        final long duration = execInfo.getElapsedTime();
+        final boolean isBatch = execInfo.isBatch();
+        final Throwable throwable = execInfo.getThrowable();
+        span.addField(TraceFieldConstants.DATABASE_QUERY_FIELD, queryInfo.getQuery());
+        span.addField(TraceFieldConstants.DATABASE_QUERY_PARAMETERS_FIELD, queryInfo.getQueryArgsList());
+        span.addField(TraceFieldConstants.DATABASE_CONNECTION_ID_FIELD, execInfo.getConnectionId());
+        span.addField(TraceFieldConstants.DATABASE_STATEMENT_TYPE_FIELD, execInfo.getStatementType().name());
+        span.addField(TraceFieldConstants.DATABASE_IS_SUCCESS, execInfo.isSuccess());
+        span.addField(TraceFieldConstants.DATABASE_IS_BATCH_FIELD, isBatch);
+        if (duration > 0) {
+            span.addField(TraceFieldConstants.DURATION_FIELD, duration);
+        }
+        if (isBatch) {
+            span.addField(TraceFieldConstants.DATABASE_BATCH_SIZE_FIELD, execInfo.getBatchSize());
+        }
+        if (throwable != null) {
+            span.addField(TraceFieldConstants.DATABASE_ERROR, throwable.getClass().getSimpleName());
+            span.addField(TraceFieldConstants.DATABASE_ERROR_DETAILS, throwable.getMessage());
+        }
+    }
+}

--- a/beeline-spring-boot-starter/src/main/java/io/honeycomb/beeline/spring/beans/BeelineQueryListenerForJDBC.java
+++ b/beeline-spring-boot-starter/src/main/java/io/honeycomb/beeline/spring/beans/BeelineQueryListenerForJDBC.java
@@ -48,7 +48,7 @@ public class BeelineQueryListenerForJDBC implements QueryExecutionListener {
         execInfo.addCustomValue(ROOT_SPAN_KEY, rootSpan);
     }
 
-    @SuppressFBWarnings("RCN_REDUNDANT_NULLCHECK_OF_NONNULL_VALUE") // JDK 11 issue https://github.com/spotbugs/spotbugs/issues/756
+    @SuppressFBWarnings({"RCN_REDUNDANT_NULLCHECK_OF_NONNULL_VALUE", "RCN_REDUNDANT_NULLCHECK_OF_NULL_VALUE", "RCN_REDUNDANT_NULLCHECK_WOULD_HAVE_BEEN_A_NPE"}) // JDK 11 issue https://github.com/spotbugs/spotbugs/issues/756
     @Override
     public void afterQuery(final ExecutionInfo execInfo, final List<QueryInfo> queryInfoList) {
         try (Span rootSpan = safelyValidateRootSpan(execInfo)) {

--- a/beeline-spring-boot-starter/src/main/java/io/honeycomb/beeline/spring/beans/BeelineQueryListenerForJDBC.java
+++ b/beeline-spring-boot-starter/src/main/java/io/honeycomb/beeline/spring/beans/BeelineQueryListenerForJDBC.java
@@ -56,7 +56,6 @@ public class BeelineQueryListenerForJDBC implements QueryExecutionListener {
                 return;
             }
             if (childSpans == null) {
-                rootSpan.close();
                 LOG.error("Child spans not found");
                 return;
             }

--- a/beeline-spring-boot-starter/src/main/java/io/honeycomb/beeline/spring/beans/BeelineQueryListenerForJDBC.java
+++ b/beeline-spring-boot-starter/src/main/java/io/honeycomb/beeline/spring/beans/BeelineQueryListenerForJDBC.java
@@ -1,5 +1,6 @@
 package io.honeycomb.beeline.spring.beans;
 
+import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 import io.honeycomb.beeline.tracing.Beeline;
 import io.honeycomb.beeline.tracing.Span;
 import io.honeycomb.beeline.tracing.Tracer;
@@ -47,6 +48,7 @@ public class BeelineQueryListenerForJDBC implements QueryExecutionListener {
         execInfo.addCustomValue(ROOT_SPAN_KEY, rootSpan);
     }
 
+    @SuppressFBWarnings("RCN_REDUNDANT_NULLCHECK_OF_NONNULL_VALUE") // JDK 11 issue https://github.com/spotbugs/spotbugs/issues/756
     @Override
     public void afterQuery(final ExecutionInfo execInfo, final List<QueryInfo> queryInfoList) {
         try (Span rootSpan = safelyValidateRootSpan(execInfo)) {

--- a/beeline-spring-boot-starter/src/main/java/io/honeycomb/beeline/spring/beans/BeelineQueryListenerForJDBC.java
+++ b/beeline-spring-boot-starter/src/main/java/io/honeycomb/beeline/spring/beans/BeelineQueryListenerForJDBC.java
@@ -48,7 +48,7 @@ public class BeelineQueryListenerForJDBC implements QueryExecutionListener {
         execInfo.addCustomValue(ROOT_SPAN_KEY, rootSpan);
     }
 
-    @SuppressFBWarnings({"RCN_REDUNDANT_NULLCHECK_OF_NONNULL_VALUE", "RCN_REDUNDANT_NULLCHECK_OF_NULL_VALUE", "RCN_REDUNDANT_NULLCHECK_WOULD_HAVE_BEEN_A_NPE"}) // JDK 11 issue https://github.com/spotbugs/spotbugs/issues/756
+    @SuppressFBWarnings({"RCN_REDUNDANT_NULLCHECK_OF_NONNULL_VALUE", "RCN_REDUNDANT_NULLCHECK_OF_NULL_VALUE", "RCN_REDUNDANT_NULLCHECK_WOULD_HAVE_BEEN_A_NPE", "NP_LOAD_OF_KNOWN_NULL_VALUE"}) // JDK 11 issue https://github.com/spotbugs/spotbugs/issues/756
     @Override
     public void afterQuery(final ExecutionInfo execInfo, final List<QueryInfo> queryInfoList) {
         try (Span rootSpan = safelyValidateRootSpan(execInfo)) {

--- a/beeline-spring-boot-starter/src/main/java/io/honeycomb/beeline/spring/beans/DataSourceProxyBeanPostProcessor.java
+++ b/beeline-spring-boot-starter/src/main/java/io/honeycomb/beeline/spring/beans/DataSourceProxyBeanPostProcessor.java
@@ -1,6 +1,5 @@
 package io.honeycomb.beeline.spring.beans;
 
-import io.honeycomb.beeline.tracing.Beeline;
 import net.ttddyy.dsproxy.support.ProxyDataSource;
 import net.ttddyy.dsproxy.support.ProxyDataSourceBuilder;
 import org.springframework.beans.factory.config.BeanPostProcessor;
@@ -9,10 +8,10 @@ import javax.sql.DataSource;
 
 public class DataSourceProxyBeanPostProcessor implements BeanPostProcessor {
 
-    private final Beeline beeline;
+    private final BeelineQueryListenerForJDBC listener;
 
-    public DataSourceProxyBeanPostProcessor(final Beeline beeline) {
-        this.beeline = beeline;
+    public DataSourceProxyBeanPostProcessor(BeelineQueryListenerForJDBC listener) {
+        this.listener = listener;
     }
 
     @Override
@@ -23,7 +22,7 @@ public class DataSourceProxyBeanPostProcessor implements BeanPostProcessor {
 
         return ProxyDataSourceBuilder.create((DataSource) bean)
             .name(beanName)
-            .listener(new BeelineQueryListenerForJDBC(beeline))
+            .listener(listener)
             .build();
     }
 

--- a/beeline-spring-boot-starter/src/main/java/io/honeycomb/beeline/spring/beans/DataSourceProxyBeanPostProcessor.java
+++ b/beeline-spring-boot-starter/src/main/java/io/honeycomb/beeline/spring/beans/DataSourceProxyBeanPostProcessor.java
@@ -1,0 +1,30 @@
+package io.honeycomb.beeline.spring.beans;
+
+import io.honeycomb.beeline.tracing.Beeline;
+import net.ttddyy.dsproxy.support.ProxyDataSource;
+import net.ttddyy.dsproxy.support.ProxyDataSourceBuilder;
+import org.springframework.beans.factory.config.BeanPostProcessor;
+
+import javax.sql.DataSource;
+
+public class DataSourceProxyBeanPostProcessor implements BeanPostProcessor {
+
+    private final Beeline beeline;
+
+    public DataSourceProxyBeanPostProcessor(final Beeline beeline) {
+        this.beeline = beeline;
+    }
+
+    @Override
+    public Object postProcessAfterInitialization(final Object bean, final String beanName) {
+        if (!DataSource.class.isAssignableFrom(bean.getClass()) || ProxyDataSource.class.isAssignableFrom(bean.getClass())) {
+            return bean;
+        }
+
+        return ProxyDataSourceBuilder.create((DataSource) bean)
+            .name(beanName)
+            .listener(new BeelineQueryListenerForJDBC(beeline))
+            .build();
+    }
+
+}

--- a/beeline-spring-boot-starter/src/test/java/io/honeycomb/beeline/spring/autoconfig/BeelineAutoconfigTest.java
+++ b/beeline-spring-boot-starter/src/test/java/io/honeycomb/beeline/spring/autoconfig/BeelineAutoconfigTest.java
@@ -321,7 +321,7 @@ public class BeelineAutoconfigTest {
     }
 
     @Test
-    public void GIVEN_jdbcDisabled_EXPECT_DataSourcePRodyBeanPostProcessorToNotBeLoaded() {
+    public void GIVEN_jdbcDisabled_EXPECT_DataSourceProxyBeanPostProcessorToNotBeLoaded() {
         webApplicationContextRunner
             .withConfiguration(AutoConfigurations.of(BeelineAutoconfig.class))
             .withPropertyValues(defaultProps)

--- a/beeline-spring-boot-starter/src/test/java/io/honeycomb/beeline/spring/autoconfig/BeelineAutoconfigTest.java
+++ b/beeline-spring-boot-starter/src/test/java/io/honeycomb/beeline/spring/autoconfig/BeelineAutoconfigTest.java
@@ -1,10 +1,11 @@
 package io.honeycomb.beeline.spring.autoconfig;
 
 import io.honeycomb.beeline.spring.beans.BeelineHandlerInterceptor;
+import io.honeycomb.beeline.spring.beans.BeelineQueryListenerForJDBC;
 import io.honeycomb.beeline.spring.beans.BeelineRestTemplateInterceptor;
 import io.honeycomb.beeline.spring.beans.DataSourceProxyBeanPostProcessor;
-import io.honeycomb.beeline.spring.beans.SpringServletFilter;
 import io.honeycomb.beeline.spring.beans.DebugResponseObserver;
+import io.honeycomb.beeline.spring.beans.SpringServletFilter;
 import io.honeycomb.beeline.tracing.Beeline;
 import io.honeycomb.beeline.tracing.Span;
 import io.honeycomb.beeline.tracing.SpanPostProcessor;
@@ -57,7 +58,8 @@ public class BeelineAutoconfigTest {
         BeelineHandlerInterceptor.class,
         BeelineRestTemplateInterceptor.class,
         BatchingHttpTransport.class,
-        DataSourceProxyBeanPostProcessor.class
+        DataSourceProxyBeanPostProcessor.class,
+        BeelineQueryListenerForJDBC.class
     );
 
     private final String[] defaultProps = {
@@ -326,6 +328,8 @@ public class BeelineAutoconfigTest {
             .withConfiguration(AutoConfigurations.of(BeelineAutoconfig.class))
             .withPropertyValues(defaultProps)
             .withPropertyValues("honeycomb.beeline.jdbc.enabled=false")
-            .run(context -> assertThat(context).doesNotHaveBean(DataSourceProxyBeanPostProcessor.class));
+            .run(context -> assertThat(context)
+                .doesNotHaveBean(DataSourceProxyBeanPostProcessor.class)
+                .doesNotHaveBean(BeelineQueryListenerForJDBC.class));
     }
 }

--- a/beeline-spring-boot-starter/src/test/java/io/honeycomb/beeline/spring/beans/BeelineQueryListenerForJDBCTest.java
+++ b/beeline-spring-boot-starter/src/test/java/io/honeycomb/beeline/spring/beans/BeelineQueryListenerForJDBCTest.java
@@ -1,0 +1,285 @@
+package io.honeycomb.beeline.spring.beans;
+
+import io.honeycomb.beeline.tracing.Beeline;
+import io.honeycomb.beeline.tracing.Span;
+import io.honeycomb.beeline.tracing.Tracer;
+import io.honeycomb.beeline.tracing.propagation.PropagationContext;
+import io.honeycomb.beeline.tracing.utils.TraceFieldConstants;
+import net.ttddyy.dsproxy.ExecutionInfo;
+import net.ttddyy.dsproxy.QueryInfo;
+import net.ttddyy.dsproxy.StatementType;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.Mock;
+import org.springframework.test.context.junit4.SpringRunner;
+
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+
+import static io.honeycomb.beeline.spring.beans.BeelineQueryListenerForJDBC.CHILD_SPAN_KEY;
+import static io.honeycomb.beeline.spring.beans.BeelineQueryListenerForJDBC.ROOT_SPAN_KEY;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyLong;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.atLeastOnce;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoInteractions;
+import static org.mockito.Mockito.when;
+
+@RunWith(SpringRunner.class)
+public class BeelineQueryListenerForJDBCTest {
+
+    @Mock
+    Beeline beeline;
+    @Mock
+    Span activeSpan;
+    @Mock
+    Span childSpan;
+    @Mock
+    Tracer tracer;
+    BeelineQueryListenerForJDBC listener;
+    ExecutionInfo executionInfo;
+
+    @Before
+    public void setUp() {
+        listener = new BeelineQueryListenerForJDBC(beeline);
+        when(beeline.getActiveSpan()).thenReturn(activeSpan);
+        when(activeSpan.isNoop()).thenReturn(false);
+        when(beeline.getTracer()).thenReturn(tracer);
+        when(tracer.startChildSpan(anyString())).thenReturn(childSpan);
+        when(beeline.startTrace(anyString(), any(PropagationContext.class), anyString())).thenReturn(activeSpan);
+        executionInfo = new ExecutionInfo();
+        executionInfo.setStatementType(StatementType.STATEMENT);
+    }
+
+    @Test
+    public void GIVEN_beforeQuery_EXPECT_spansOnExecutionInfo() {
+        final List<QueryInfo> queryInfoList = Collections.singletonList(new QueryInfo("query1"));
+
+        listener.beforeQuery(executionInfo, queryInfoList);
+
+        final Span rootSpan = executionInfo.getCustomValue(ROOT_SPAN_KEY, Span.class);
+        final List<?> childSpans = executionInfo.getCustomValue(CHILD_SPAN_KEY, List.class);
+        assertThat(rootSpan).isNotNull();
+        assertThat(childSpans).isNotNull().hasSize(1);
+        verify(childSpan, times(1)).markStart();
+    }
+
+    @Test
+    public void GIVEN_beforeQueryBatch_EXPECT_spansOnExecutionInfo() {
+        final List<QueryInfo> queryInfoList = Arrays.asList(new QueryInfo("query1"), new QueryInfo("query2"));
+
+        listener.beforeQuery(executionInfo, queryInfoList);
+
+        final Span rootSpan = executionInfo.getCustomValue(ROOT_SPAN_KEY, Span.class);
+        final List<?> childSpans = executionInfo.getCustomValue(CHILD_SPAN_KEY, List.class);
+        assertThat(rootSpan).isNotNull();
+        assertThat(childSpans).isNotNull().hasSize(2);
+        verify(childSpan, times(2)).markStart();
+    }
+
+    @Test
+    public void GIVEN_afterQuery_EXPECT_fieldsOnSpan() {
+        executionInfo.setElapsedTime(0);
+        executionInfo.setStatementType(StatementType.STATEMENT);
+        final List<QueryInfo> queryInfoList = Collections.singletonList(new QueryInfo("query1"));
+        executionInfo.addCustomValue(CHILD_SPAN_KEY, Collections.singletonList(childSpan));
+        executionInfo.addCustomValue(ROOT_SPAN_KEY, activeSpan);
+
+        listener.afterQuery(executionInfo, queryInfoList);
+
+        verifyAddedFieldsToSpan(1);
+    }
+
+    /**
+     * This helper method checks for default fields being added to span. We re-use the child span mock object so each
+     * of these fields should be hit based on the number of times it has been processed. If there are 2 queries, the
+     * mock child span should have been processed twice.
+     * @param multiplier the number of child spans that should have been processed
+     */
+    private void verifyAddedFieldsToSpan(final int multiplier) {
+        verify(childSpan, times(multiplier)).addField(eq(TraceFieldConstants.DATABASE_QUERY_FIELD), any());
+        verify(childSpan, times(multiplier)).addField(eq(TraceFieldConstants.DATABASE_QUERY_PARAMETERS_FIELD), any());
+        verify(childSpan, times(multiplier)).addField(eq(TraceFieldConstants.DATABASE_CONNECTION_ID_FIELD), any());
+        verify(childSpan, times(multiplier)).addField(eq(TraceFieldConstants.DATABASE_STATEMENT_TYPE_FIELD), any());
+        verify(childSpan, times(multiplier)).addField(eq(TraceFieldConstants.DATABASE_IS_SUCCESS), any());
+        verify(childSpan, times(multiplier)).addField(eq(TraceFieldConstants.DATABASE_IS_BATCH_FIELD), any());
+    }
+
+    @Test
+    public void GIVEN_afterQueryWithDuration_EXPECT_durationOnSpan() {
+        final long duration = 100L;
+        executionInfo.setElapsedTime(duration);
+        final List<QueryInfo> queryInfoList = Collections.singletonList(new QueryInfo("query1"));
+        executionInfo.addCustomValue(CHILD_SPAN_KEY, Collections.singletonList(childSpan));
+        executionInfo.addCustomValue(ROOT_SPAN_KEY, activeSpan);
+
+        listener.afterQuery(executionInfo, queryInfoList);
+
+        final Span rootSpan = executionInfo.getCustomValue(ROOT_SPAN_KEY, Span.class);
+        final List<?> childSpans = executionInfo.getCustomValue(CHILD_SPAN_KEY, List.class);
+        assertThat(rootSpan).isNotNull();
+        assertThat(childSpans).isNotNull().hasSize(1);
+        verify(childSpan, times(1)).addField(eq(TraceFieldConstants.DURATION_FIELD), anyLong());
+        verifyAddedFieldsToSpan(1);
+    }
+
+
+    @Test
+    public void GIVEN_afterQueryNoDuration_EXPECT_durationMissingOnSpan() {
+        executionInfo.setElapsedTime(0);
+        final List<QueryInfo> queryInfoList = Collections.singletonList(new QueryInfo("query1"));
+        executionInfo.addCustomValue(CHILD_SPAN_KEY, Collections.singletonList(childSpan));
+        executionInfo.addCustomValue(ROOT_SPAN_KEY, activeSpan);
+
+        listener.afterQuery(executionInfo, queryInfoList);
+
+        verify(childSpan, times(0)).addField(eq(TraceFieldConstants.DURATION_FIELD), anyLong());
+        verifyAddedFieldsToSpan(1);
+    }
+
+    @Test
+    public void GIVEN_afterQueryBatch_EXPECT_batchSizeOnSpan() {
+        executionInfo.setBatch(true);
+        executionInfo.setBatchSize(2);
+        final List<QueryInfo> queryInfoList = Arrays.asList(new QueryInfo("query1"), new QueryInfo("query2"));
+        executionInfo.addCustomValue(CHILD_SPAN_KEY, Arrays.asList(childSpan, childSpan));
+        executionInfo.addCustomValue(ROOT_SPAN_KEY, activeSpan);
+
+        listener.afterQuery(executionInfo, queryInfoList);
+
+        verify(childSpan, times(2)).addField(eq(TraceFieldConstants.DATABASE_BATCH_SIZE_FIELD), eq(2));
+        verifyAddedFieldsToSpan(2);
+
+    }
+
+    @Test
+    public void GIVEN_afterQueryNoBatch_EXPECT_batchSizeMissingFromSpan() {
+        executionInfo.setBatch(false);
+        final List<QueryInfo> queryInfoList = Collections.singletonList(new QueryInfo("query1"));
+        executionInfo.addCustomValue(CHILD_SPAN_KEY, Collections.singletonList(childSpan));
+        executionInfo.addCustomValue(ROOT_SPAN_KEY, activeSpan);
+
+        listener.afterQuery(executionInfo, queryInfoList);
+
+        verify(childSpan, times(0)).addField(eq(TraceFieldConstants.DATABASE_BATCH_SIZE_FIELD), anyLong());
+        verifyAddedFieldsToSpan(1);
+
+    }
+
+    @Test
+    public void GIVEN_afterQueryThrowable_EXPECT_errorMessageOnSpan() {
+        final String errorMessage = "some message";
+        final Throwable throwable = new Throwable(errorMessage);
+        executionInfo.setThrowable(throwable);
+        final List<QueryInfo> queryInfoList = Collections.singletonList(new QueryInfo("query1"));
+        executionInfo.addCustomValue(CHILD_SPAN_KEY, Collections.singletonList(childSpan));
+        executionInfo.addCustomValue(ROOT_SPAN_KEY, activeSpan);
+
+        listener.afterQuery(executionInfo, queryInfoList);
+
+        verify(childSpan, times(1)).addField(eq(TraceFieldConstants.DATABASE_ERROR), eq("Throwable"));
+        verify(childSpan, times(1)).addField(eq(TraceFieldConstants.DATABASE_ERROR_DETAILS), eq(errorMessage));
+        verifyAddedFieldsToSpan(1);
+    }
+
+    @Test
+    public void GIVEN_afterQueryMissingThrowable_EXPECT_errorMessageMissingOnSpan() {
+        final List<QueryInfo> queryInfoList = Collections.singletonList(new QueryInfo("query1"));
+        executionInfo.addCustomValue(CHILD_SPAN_KEY, Collections.singletonList(childSpan));
+        executionInfo.addCustomValue(ROOT_SPAN_KEY, activeSpan);
+
+        listener.afterQuery(executionInfo, queryInfoList);
+
+        verify(childSpan, times(0)).addField(eq(TraceFieldConstants.DATABASE_ERROR), eq("Throwable"));
+        verify(childSpan, times(0)).addField(eq(TraceFieldConstants.DATABASE_ERROR_DETAILS), anyString());
+        verifyAddedFieldsToSpan(1);
+    }
+
+    @Test
+    public void GIVEN_afterQueryCouldNotConvertRootSpan_EXPECT_nothingToHappen() {
+        final List<QueryInfo> queryInfoList = Collections.singletonList(new QueryInfo("query1"));
+        final Object nonSpan = new Object();
+        executionInfo.addCustomValue(ROOT_SPAN_KEY, nonSpan);
+
+        listener.afterQuery(executionInfo, queryInfoList);
+
+        verifyNoInteractions(activeSpan, childSpan);
+    }
+
+    @Test
+    public void GIVEN_afterQueryCouldNotConvertChildSpanList_EXPECT_invalidSpanDataDroppedButRootSpanClosed() {
+        final List<QueryInfo> queryInfoList = Collections.singletonList(new QueryInfo("query1"));
+        final Object nonSpan = mock(Mock.class);
+        executionInfo.addCustomValue(ROOT_SPAN_KEY, activeSpan);
+        executionInfo.addCustomValue(CHILD_SPAN_KEY, nonSpan);
+
+        listener.afterQuery(executionInfo, queryInfoList);
+
+        verifyNoInteractions(nonSpan, childSpan);
+        verify(activeSpan, atLeastOnce()).close();
+    }
+    @Test
+    public void GIVEN_afterQueryCouldNotConvertChildSpan_EXPECT_invalidSpanDataDroppedButRootSpanClosed() {
+        final List<QueryInfo> queryInfoList = Collections.singletonList(new QueryInfo("query1"));
+        final Object nonSpan = mock(Mock.class);
+        executionInfo.addCustomValue(ROOT_SPAN_KEY, activeSpan);
+        executionInfo.addCustomValue(CHILD_SPAN_KEY, Collections.singletonList(nonSpan));
+
+        listener.afterQuery(executionInfo, queryInfoList);
+
+        verifyNoInteractions(nonSpan, childSpan);
+        verify(activeSpan, atLeastOnce()).close();
+    }
+
+    @Test
+    public void GIVEN_afterQueryLessSpansThanQueries_EXPECT_onlyProcessNumberOfSpans() {
+        final List<QueryInfo> queryInfoList = Arrays.asList(new QueryInfo("query1"), new QueryInfo("query2"));
+        executionInfo.addCustomValue(ROOT_SPAN_KEY, activeSpan);
+        executionInfo.addCustomValue(CHILD_SPAN_KEY, Collections.singletonList(childSpan));
+
+        listener.afterQuery(executionInfo, queryInfoList);
+
+        verifyAddedFieldsToSpan(1);
+    }
+
+    @Test
+    public void GIVEN_afterQueryMoreSpansThanQueries_EXPECT_onlyProcessNumberOfQueries() {
+        final List<QueryInfo> queryInfoList = Collections.singletonList(new QueryInfo("query1"));
+        executionInfo.addCustomValue(ROOT_SPAN_KEY, activeSpan);
+        executionInfo.addCustomValue(CHILD_SPAN_KEY, Arrays.asList(childSpan, childSpan));
+
+        listener.afterQuery(executionInfo, queryInfoList);
+
+        verifyAddedFieldsToSpan(1);
+    }
+
+    @Test
+    public void GIVEN_afterQueryMissingChildSpans_EXPECT_rootSpanToBeClosed() {
+        final List<QueryInfo> queryInfoList = Collections.singletonList(new QueryInfo("query1"));
+        executionInfo.addCustomValue(ROOT_SPAN_KEY, activeSpan);
+        executionInfo.addCustomValue(CHILD_SPAN_KEY, null);
+
+        listener.afterQuery(executionInfo, queryInfoList);
+
+        verifyAddedFieldsToSpan(0);
+        verify(activeSpan, atLeastOnce()).close();
+    }
+
+    @Test
+    public void GIVEN_afterQueryMissingRootSpan_EXPECT_nothingToHappen() {
+        final List<QueryInfo> queryInfoList = Collections.singletonList(new QueryInfo("query1"));
+        executionInfo.addCustomValue(ROOT_SPAN_KEY, null);
+        executionInfo.addCustomValue(CHILD_SPAN_KEY, null);
+
+        listener.afterQuery(executionInfo, queryInfoList);
+
+        verifyNoInteractions(activeSpan, childSpan);
+    }
+}

--- a/beeline-spring-boot-starter/src/test/java/io/honeycomb/beeline/spring/beans/DataSourceProxyBeanPostProcessorTest.java
+++ b/beeline-spring-boot-starter/src/test/java/io/honeycomb/beeline/spring/beans/DataSourceProxyBeanPostProcessorTest.java
@@ -1,6 +1,5 @@
 package io.honeycomb.beeline.spring.beans;
 
-import io.honeycomb.beeline.tracing.Beeline;
 import net.ttddyy.dsproxy.support.ProxyDataSource;
 import org.junit.Before;
 import org.junit.Test;
@@ -19,13 +18,13 @@ import static org.mockito.Mockito.mock;
 @RunWith(SpringRunner.class)
 public class DataSourceProxyBeanPostProcessorTest {
     @Mock
-    Beeline beeline;
+    BeelineQueryListenerForJDBC listener;
 
     DataSourceProxyBeanPostProcessor processor;
 
     @Before
     public void setUp() {
-        processor = new DataSourceProxyBeanPostProcessor(beeline);
+        processor = new DataSourceProxyBeanPostProcessor(listener);
     }
 
     @Test

--- a/beeline-spring-boot-starter/src/test/java/io/honeycomb/beeline/spring/beans/DataSourceProxyBeanPostProcessorTest.java
+++ b/beeline-spring-boot-starter/src/test/java/io/honeycomb/beeline/spring/beans/DataSourceProxyBeanPostProcessorTest.java
@@ -1,0 +1,106 @@
+package io.honeycomb.beeline.spring.beans;
+
+import io.honeycomb.beeline.tracing.Beeline;
+import net.ttddyy.dsproxy.support.ProxyDataSource;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.Mock;
+import org.springframework.test.context.junit4.SpringRunner;
+
+import javax.sql.DataSource;
+import java.io.PrintWriter;
+import java.sql.Connection;
+import java.util.logging.Logger;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.mock;
+
+@RunWith(SpringRunner.class)
+public class DataSourceProxyBeanPostProcessorTest {
+    @Mock
+    Beeline beeline;
+
+    DataSourceProxyBeanPostProcessor processor;
+
+    @Before
+    public void setUp() {
+        processor = new DataSourceProxyBeanPostProcessor(beeline);
+    }
+
+    @Test
+    public void GIVEN_DataSource_EXPECT_ProxiedDataSource() {
+        final DataSource dataSource = mock(DataSource.class);
+        final Object o = processor.postProcessAfterInitialization(dataSource, "name");
+        assertThat(o).isInstanceOf(ProxyDataSource.class);
+    }
+
+    @Test
+    public void GIVEN_ProxiedDataSource_EXPECT_objectIsSameObject() {
+        final DataSource dataSource = mock(ProxyDataSource.class);
+        final Object o = processor.postProcessAfterInitialization(dataSource, "name");
+        assertThat(o).isSameAs(dataSource);
+    }
+
+    @Test
+    public void GIVEN_otherObject_EXEPCT_objectIsSameObject() {
+        final String sourceObj = "object";
+        final Object o = processor.postProcessAfterInitialization(sourceObj, "name");
+        assertThat(o).isSameAs(sourceObj);
+    }
+
+    @Test
+    public void GIVEN_CustomDataSource_EXPECT_ProxiedDataSource() {
+        final DataSource dataSource = mock(CustomDataSource.class);
+        final Object o = processor.postProcessAfterInitialization(dataSource, "name");
+        assertThat(o).isInstanceOf(ProxyDataSource.class);
+    }
+
+    private static class CustomDataSource implements DataSource {
+
+        @Override
+        public Connection getConnection() {
+            return null;
+        }
+
+        @Override
+        public Connection getConnection(final String username, final String password) {
+            return null;
+        }
+
+        @Override
+        public <T> T unwrap(final Class<T> iface) {
+            return null;
+        }
+
+        @Override
+        public boolean isWrapperFor(final Class<?> iface) {
+            return false;
+        }
+
+        @Override
+        public PrintWriter getLogWriter() {
+            return null;
+        }
+
+        @Override
+        public void setLogWriter(final PrintWriter out) {
+
+        }
+
+        @Override
+        public int getLoginTimeout() {
+            return 0;
+        }
+
+        @Override
+        public void setLoginTimeout(final int seconds) {
+
+        }
+
+        @Override
+        public Logger getParentLogger() {
+            return null;
+        }
+    }
+}

--- a/beeline-spring-boot-starter/src/test/java/io/honeycomb/beeline/spring/mockmvctests/MockMvcTest.java
+++ b/beeline-spring-boot-starter/src/test/java/io/honeycomb/beeline/spring/mockmvctests/MockMvcTest.java
@@ -114,8 +114,8 @@ public class MockMvcTest {
         assertThat(eventFields).containsKey("meta.beeline_version");
         assertThat(eventFields).containsEntry("meta.package", "Spring Boot");
         assertThat(eventFields).containsKey("meta.package_version");
-        assertThat((Iterable<String>) eventFields.get("meta.instrumentations")).containsExactlyInAnyOrder("spring_mvc", "spring_aop", "spring_rest_template");
-        assertThat(eventFields).containsEntry("meta.instrumentation_count", 3);
+        assertThat((Iterable<String>) eventFields.get("meta.instrumentations")).containsExactlyInAnyOrder("spring_mvc", "spring_aop", "spring_rest_template", "spring_jdbc");
+        assertThat(eventFields).containsEntry("meta.instrumentation_count", 4);
         assertThat(eventFields).containsEntry("meta.local_hostname", tryGetLocalHostname());
     }
 


### PR DESCRIPTION
This automatically proxies DataSource and adds query listener to Spring. This will use the Beeline to send JDBC traces to Honeycomb.

To disable this behavior, set `honeycomb.beeline.jdbc.enabled=false` in Spring's application properties.