### PR TITLE
Add support for W3C Trace and Span ID generation

### DIFF
--- a/beeline-core/src/main/java/io/honeycomb/beeline/tracing/SpanBuilderFactory.java
+++ b/beeline-core/src/main/java/io/honeycomb/beeline/tracing/SpanBuilderFactory.java
@@ -114,7 +114,7 @@ public class SpanBuilderFactory {
     }
 
     public String generateId() {
-        return idProvider.generateId();
+        return idProvider.generateTraceId();
     }
 
     public SpanPostProcessor getProcessor() {
@@ -262,7 +262,7 @@ public class SpanBuilderFactory {
          * @throws IllegalArgumentException if required attributes are not set.
          */
         public Span build() {
-            final String traceId = parentContext.isTraced() ? parentContext.getTraceId() : idProvider.generateId();
+            final String traceId = parentContext.isTraced() ? parentContext.getTraceId() : idProvider.generateTraceId();
             final int sampleRate = traceSampler.sample(traceId);
             LOG.debug("Building span - sampling decision for traceId '{}' is '{}'", traceId, sampleRate);
             return sampleRate > 0 ? createSendingSpan(sampleRate, traceId) : Span.getNoopInstance();
@@ -275,7 +275,7 @@ public class SpanBuilderFactory {
             final Span span = new SendingSpan(
                 spanName,
                 serviceName,
-                spanId == null ? idProvider.generateId() : spanId,
+                spanId == null ? idProvider.generateSpanId() : spanId,
                 fields,
                 context,
                 processor,

--- a/beeline-core/src/main/java/io/honeycomb/beeline/tracing/Tracing.java
+++ b/beeline-core/src/main/java/io/honeycomb/beeline/tracing/Tracing.java
@@ -1,7 +1,7 @@
 package io.honeycomb.beeline.tracing;
 
 import io.honeycomb.beeline.tracing.ids.TraceIdProvider;
-import io.honeycomb.beeline.tracing.ids.UUIDTraceIdProvider;
+import io.honeycomb.beeline.tracing.ids.W3CTraceIdProvider;
 import io.honeycomb.beeline.tracing.sampling.TraceSampler;
 import io.honeycomb.beeline.tracing.context.TracingContext;
 import io.honeycomb.libhoney.HoneyClient;
@@ -19,7 +19,7 @@ import io.honeycomb.libhoney.transport.batch.impl.SystemClockProvider;
  */
 public final class Tracing {
     private static final ClockProvider CLOCK = SystemClockProvider.getInstance();
-    private static final TraceIdProvider ID_PROVIDER = UUIDTraceIdProvider.getInstance();
+    private static final TraceIdProvider ID_PROVIDER = W3CTraceIdProvider.getInstance();
 
     private Tracing() {
         // utils class

--- a/beeline-core/src/main/java/io/honeycomb/beeline/tracing/ids/TraceIdProvider.java
+++ b/beeline-core/src/main/java/io/honeycomb/beeline/tracing/ids/TraceIdProvider.java
@@ -7,5 +7,9 @@ package io.honeycomb.beeline.tracing.ids;
  * Implementations must be thread-safe and so that they can be shared.
  */
 public interface TraceIdProvider {
+    @Deprecated
     String generateId();
+
+    String generateTraceId();
+    String generateSpanId();
 }

--- a/beeline-core/src/main/java/io/honeycomb/beeline/tracing/ids/UUIDTraceIdProvider.java
+++ b/beeline-core/src/main/java/io/honeycomb/beeline/tracing/ids/UUIDTraceIdProvider.java
@@ -9,6 +9,7 @@ import java.util.UUID;
  * <h1>Thread-safety</h1>
  * Instances of this class are thread-safe and can be shared.
  */
+@Deprecated
 public class UUIDTraceIdProvider implements TraceIdProvider {
     private static final TraceIdProvider INSTANCE = new UUIDTraceIdProvider();
 
@@ -19,5 +20,15 @@ public class UUIDTraceIdProvider implements TraceIdProvider {
     @Override
     public String generateId() {
         return UUID.randomUUID().toString();
+    }
+
+    @Override
+    public String generateTraceId() {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public String generateSpanId() {
+        throw new UnsupportedOperationException();
     }
 }

--- a/beeline-core/src/main/java/io/honeycomb/beeline/tracing/ids/W3CTraceIdProvider.java
+++ b/beeline-core/src/main/java/io/honeycomb/beeline/tracing/ids/W3CTraceIdProvider.java
@@ -1,0 +1,92 @@
+package io.honeycomb.beeline.tracing.ids;
+
+import java.util.Random;
+
+/**
+ * Creates Trace and Span IDs that conform to the W3C specification.
+ * This is inline with Beeline instrumentations in other programming languages.
+ *
+ * <h1>Thread-safety</h1>
+ * Instances of this class are thread-safe and can be shared.
+ */
+public class W3CTraceIdProvider implements TraceIdProvider {
+    private static final TraceIdProvider INSTANCE = new W3CTraceIdProvider();
+    private static final Random RAND = new Random();
+    private static final int TRACEID_LENGTH = 16;
+    private static final int SPANID_LENGTH = 8;
+
+    public static TraceIdProvider getInstance() {
+        return INSTANCE;
+    }
+
+    @Override
+    public String generateId() {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public String generateTraceId() {
+        byte[] bytes = new byte[TRACEID_LENGTH];
+        RAND.nextBytes(bytes);
+        return bytesToHex(bytes);
+    }
+
+    @Override
+    public String generateSpanId() {
+        byte[] bytes = new byte[SPANID_LENGTH];
+        RAND.nextBytes(bytes);
+        return bytesToHex(bytes);
+    }
+
+    // Taken from Stackoverflow post: https://stackoverflow.com/a/9855338/329666
+    private static final char[] HEX_ARRAY = "0123456789abcdef".toCharArray();
+
+    private static String bytesToHex(byte[] bytes) {
+        char[] hexChars = new char[bytes.length * 2];
+        for (int j = 0; j < bytes.length; j++) {
+            int v = bytes[j] & 0xFF;
+            hexChars[j * 2] = HEX_ARRAY[v >>> 4];
+            hexChars[j * 2 + 1] = HEX_ARRAY[v & 0x0F];
+        }
+        return new String(hexChars);
+    }
+
+    /**
+     * Validates the provided traceId.
+     * Intended for internal use only.
+     * @param traceId
+     * @throws IllegalArgumentException
+     *         If the traceId is not valid.
+     */
+    public static void validateTraceId(String traceId) {
+        if (traceId.isEmpty() ||
+            traceId.length() != 32 ||
+            !isHexString(traceId)) {
+            throw new IllegalArgumentException("Invalid TraceID string: " + traceId);
+        }
+    }
+
+    /**
+     * Validates the provided spanId.
+     * Intended for internal use only.
+     * @param traceId
+     * @throws IllegalArgumentException
+     *         If the spanId is not valid.
+     */
+    public static void validateSpanId(String spanId) {
+        if (spanId.isEmpty() ||
+            spanId.length() != 16 ||
+            !isHexString(spanId)) {
+            throw new IllegalArgumentException("Invalid SpanID string: " + spanId);
+        }
+    }
+
+    private static Boolean isHexString(String id) {
+        for (int i = 0; i < id.length(); i++) {
+            if ( Character.digit(id.charAt(i), 16) == -1) {
+                return false;
+            }
+        }
+        return true;
+    }
+}

--- a/beeline-core/src/test/java/io/honeycomb/beeline/tracing/TracerTest.java
+++ b/beeline-core/src/test/java/io/honeycomb/beeline/tracing/TracerTest.java
@@ -1,6 +1,6 @@
 package io.honeycomb.beeline.tracing;
 
-import io.honeycomb.beeline.tracing.ids.UUIDTraceIdProvider;
+import io.honeycomb.beeline.tracing.ids.W3CTraceIdProvider;
 import io.honeycomb.beeline.tracing.propagation.PropagationContext;
 import io.honeycomb.beeline.tracing.sampling.Sampling;
 import io.honeycomb.libhoney.HoneyClient;
@@ -59,7 +59,7 @@ public class TracerTest {
             .setWriteKey("testWriteKey")
             .build(), mockTransport);
         final SpanPostProcessor spanPostProcessor = new SpanPostProcessor(client, Sampling.alwaysSampler());
-        factory = new SpanBuilderFactory(spanPostProcessor, SystemClockProvider.getInstance(), UUIDTraceIdProvider.getInstance(), Sampling.alwaysSampler());
+        factory = new SpanBuilderFactory(spanPostProcessor, SystemClockProvider.getInstance(), W3CTraceIdProvider.getInstance(), Sampling.alwaysSampler());
         tracer = new Tracer(factory);
 
     }

--- a/beeline-core/src/test/java/io/honeycomb/beeline/tracing/TracingTest.java
+++ b/beeline-core/src/test/java/io/honeycomb/beeline/tracing/TracingTest.java
@@ -1,11 +1,10 @@
 package io.honeycomb.beeline.tracing;
 
+import io.honeycomb.beeline.tracing.ids.W3CTraceIdProvider;
 import io.honeycomb.beeline.tracing.sampling.Sampling;
 import io.honeycomb.libhoney.HoneyClient;
 import io.honeycomb.libhoney.transport.batch.impl.SystemClockProvider;
 import org.junit.Test;
-
-import java.util.UUID;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.Mockito.mock;
@@ -26,7 +25,7 @@ public class TracingTest {
         assertThat(factory.getProcessor()).isSameAs(mock);
         assertThat(factory.getSampler()).isSameAs(Sampling.alwaysSampler());
         assertThat(factory.getClock()).isSameAs(SystemClockProvider.getInstance());
-        assertThat(factory.generateId()).satisfies(UUID::fromString);
+        assertThat(factory.generateId()).satisfies(W3CTraceIdProvider::validateTraceId);
     }
 
     @Test

--- a/beeline-core/src/test/java/io/honeycomb/beeline/tracing/ids/UUIDTraceIdProviderTest.java
+++ b/beeline-core/src/test/java/io/honeycomb/beeline/tracing/ids/UUIDTraceIdProviderTest.java
@@ -14,4 +14,14 @@ public class UUIDTraceIdProviderTest {
 
         assertThat(uuid).isNotNull();
     }
+
+    @Test(expected = UnsupportedOperationException.class)
+    public void checkThatValidTraceIdsAreCreated() {
+        UUIDTraceIdProvider.getInstance().generateTraceId();
+    }
+
+    @Test(expected = UnsupportedOperationException.class)
+    public void checkThatValidSpanIdsAreCreated() {
+        UUIDTraceIdProvider.getInstance().generateSpanId();
+    }
 }

--- a/beeline-core/src/test/java/io/honeycomb/beeline/tracing/ids/W3CTRaceIdProviderTest.java
+++ b/beeline-core/src/test/java/io/honeycomb/beeline/tracing/ids/W3CTRaceIdProviderTest.java
@@ -1,0 +1,30 @@
+package io.honeycomb.beeline.tracing.ids;
+
+import org.junit.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class W3CTRaceIdProviderTest {
+    @Test(expected = UnsupportedOperationException.class)
+    public void checkThatValidUUIDsAreProduced() {
+        W3CTraceIdProvider.getInstance().generateId();
+    }
+
+    @Test
+    public void checkThatValidTraceIdsAreCreated() {
+        String traceId = W3CTraceIdProvider.getInstance().generateTraceId();
+
+        assertThat(traceId).isNotNull();
+        assertThat(traceId.length()).isEqualTo(32);
+        assertThat(traceId).isEqualTo(traceId.toLowerCase());
+    }
+
+    @Test
+    public void checkThatValidSpanIdsAreCreated() {
+        String spanId = W3CTraceIdProvider.getInstance().generateSpanId();
+
+        assertThat(spanId).isNotNull();
+        assertThat(spanId.length()).isEqualTo(16);
+        assertThat(spanId).isEqualTo(spanId.toLowerCase());
+    }
+}

--- a/beeline-spring-boot-starter/src/test/java/io/honeycomb/beeline/spring/e2e/End2EndTest.java
+++ b/beeline-spring-boot-starter/src/test/java/io/honeycomb/beeline/spring/e2e/End2EndTest.java
@@ -4,6 +4,8 @@ import com.github.tomakehurst.wiremock.client.WireMock;
 import com.github.tomakehurst.wiremock.common.Slf4jNotifier;
 import com.github.tomakehurst.wiremock.core.WireMockConfiguration;
 import com.github.tomakehurst.wiremock.junit.WireMockRule;
+
+import io.honeycomb.beeline.tracing.ids.W3CTraceIdProvider;
 import io.honeycomb.beeline.tracing.sampling.TraceSampler;
 import io.honeycomb.libhoney.eventdata.ResolvedEvent;
 import io.honeycomb.libhoney.responses.ResponseObservable;
@@ -192,8 +194,8 @@ public class End2EndTest {
         final List<ResolvedEvent> resolvedEvents = captureNoOfEvents(1);
         final ResolvedEvent requestEvent = resolvedEvents.get(0);
 
-        assertThat(fieldStringOf(requestEvent, "trace.span_id")).satisfies(UUID::fromString);
-        assertThat(fieldStringOf(requestEvent, "trace.trace_id")).satisfies(UUID::fromString);
+        assertThat(fieldStringOf(requestEvent, "trace.span_id")).satisfies(W3CTraceIdProvider::validateSpanId);
+        assertThat(fieldStringOf(requestEvent, "trace.trace_id")).satisfies(W3CTraceIdProvider::validateTraceId);
         assertThat(requestEvent.getFields())
             .contains(
                 entry("type", "http_server"),


### PR DESCRIPTION
Adds support for W3C Trace (16 byte) and Span (8 byte) IDs.

This changed has the following parts:
- extend TraceIdProvider to create separete Trace and Span IDs
- implement new functions in UUIDTraceIdProvider that return UnsupportedOperationException
- add W3CTraceIdProvider and tests
- update direct usage of UUIDTraceIdProvider to W3CTraceIdProvider in SpanBuilderFactory and tests