### PR TITLE
Add support for W3C http header propagation

### DIFF
--- a/beeline-core/src/main/java/io/honeycomb/beeline/tracing/propagation/Propagation.java
+++ b/beeline-core/src/main/java/io/honeycomb/beeline/tracing/propagation/Propagation.java
@@ -15,7 +15,7 @@ public final class Propagation {
     }
 
     /**
-     * Codec that can decode/encode trace context based on Version 1 of the honeycomb http header ('x-honeycomb-trace').
+     * Codec that can decode/encode trace context based on Version 1 of the Honeycomb http header ('x-honeycomb-trace').
      *
      * @return a codec.
      */
@@ -30,5 +30,14 @@ public final class Propagation {
      */
     public static PropagationCodec<String> aws() {
         return AWSPropagationCodec.getInstance();
+    }
+
+    /**
+     * Codec that can decode/encode trace context based on Version 1 of the W3C http header ('traceparent').
+     *
+     * @return a codec.
+     */
+    public static PropagationCodec<String> w3c() {
+        return HttpHeaderV1PropagationCodec.getInstance();
     }
 }

--- a/beeline-core/src/main/java/io/honeycomb/beeline/tracing/propagation/W3CPropagationCodec.java
+++ b/beeline-core/src/main/java/io/honeycomb/beeline/tracing/propagation/W3CPropagationCodec.java
@@ -30,7 +30,6 @@ public class W3CPropagationCodec implements PropagationCodec<String> {
 
     // @formatter:off
     public static final String W3C_TRACEPARENT_HEADER       = "traceparent";
-    public static final String W3C_TRACESTATE_HEADER        = "tracestate";
 
     private static final String DEFAULT_VERSION             = "00";
     private static final String NOT_SAMPLED_TRACEFLAGS      = "00";

--- a/beeline-core/src/main/java/io/honeycomb/beeline/tracing/propagation/W3CPropagationCodec.java
+++ b/beeline-core/src/main/java/io/honeycomb/beeline/tracing/propagation/W3CPropagationCodec.java
@@ -1,0 +1,132 @@
+package io.honeycomb.beeline.tracing.propagation;
+
+import java.util.Optional;
+import java.util.regex.Pattern;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import io.honeycomb.beeline.tracing.ids.W3CTraceIdProvider;
+
+import static io.honeycomb.libhoney.utils.ObjectUtils.isNullOrEmpty;
+
+/**
+ * Codec that can decode/encode trace context based on the W3C http header ('traceparent').
+ * Prefer the {@link Propagation#w3c()} factory method to retrieve an instance.
+ * <p>
+ * This implementation does not support the 'tracecontext' http header so no tracefields can be extracted or
+ * encoded.
+ * <p>
+ * The design of this class avoids throwing exceptions in favour of logging warnings and returning null on encode
+ * or an "empty context" on decode.
+ *
+ * <h1>Thread-safety</h1>
+ * Instances of this class are thread-safe and can be shared.
+ */
+public class W3CPropagationCodec implements PropagationCodec<String> {
+
+    private static final Logger LOG = LoggerFactory.getLogger(W3CPropagationCodec.class);
+    private static final W3CPropagationCodec INSTANCE = new W3CPropagationCodec();
+
+    // @formatter:off
+    public static final String W3C_TRACEPARENT_HEADER       = "traceparent";
+    public static final String W3C_TRACESTATE_HEADER        = "tracestate";
+
+    private static final String DEFAULT_VERSION             = "00";
+    private static final String NOT_SAMPLED_TRACEFLAGS      = "00";
+    private static final String SAMPLED_TRACEFLAGS          = "01";
+    private static final String SEGMENT_SEPARATOR           = "-";
+    private static final Pattern SPLIT_SEGMENTS_PATTERN     = Pattern.compile(SEGMENT_SEPARATOR);
+
+    private static final int HEADER_LENGTH                  = 55; // {version:2}-{trace-id:32}-{parent-id:16}-{traceflags:2}
+    // @formatter:on
+
+    public static W3CPropagationCodec getInstance() {
+        return INSTANCE;
+    }
+
+    /**
+     * This decodes the 'traceparent' header of the following format:
+     * <p>
+     * {@code {version}-{traceId}-{spanId}-{traceflags}}
+     * <p>
+     *
+     * </p>
+     *
+     * @param encodedTrace to decode into a {@link PropagationContext}.
+     * @return extracted context - "empty" context if encodedTrace value has an invalid format or is null.
+     */
+    @Override
+    public PropagationContext decode(String encodedTrace) {
+        // Header must not be empty and be 55 characters long
+        if (isNullOrEmpty(encodedTrace) || encodedTrace.length() != HEADER_LENGTH) {
+            return PropagationContext.emptyContext();
+        }
+
+        // Header should have four parts
+        final String[] segments = SPLIT_SEGMENTS_PATTERN.split(encodedTrace);
+        if (segments.length != 4) {
+            LOG.warn("Invalid W3C trace header: {}", encodedTrace);
+            return PropagationContext.emptyContext();
+        }
+
+        // Only allow version '00'
+        if (!segments[0].equals(DEFAULT_VERSION)) {
+            LOG.warn("Invalid header version header: {}", encodedTrace);
+            return PropagationContext.emptyContext();
+        }
+
+        // Check TraceId length is 32 characters and it is valid (none zero)
+        if (!W3CTraceIdProvider.isValidTraceId(segments[1])) {
+            LOG.warn("Invalid TraceId: {}", segments[1]);
+            return PropagationContext.emptyContext();
+        }
+
+        // Check SpanId length is 16 characters and it is valid (none zero)
+        if (!W3CTraceIdProvider.isValidSpanId(segments[2])) {
+            LOG.warn("Invalid SpanId: {}", segments[2]);
+            return PropagationContext.emptyContext();
+        }
+
+        // Check TraceFlags is valid
+        if (!segments[3].equals(SAMPLED_TRACEFLAGS) && !segments[3].equals(NOT_SAMPLED_TRACEFLAGS)) {
+            LOG.warn("Invalid TraceFlags: {}", segments[3]);
+            return PropagationContext.emptyContext();
+        }
+
+        return new PropagationContext(segments[1], segments[2], null, null);
+    }
+
+    /**
+     * This encodes the given propagation context in the format accepted by the W3C 'traceparent' http header.
+     * This will return null if the span id or trace id are not set (i.e. the context is not an active trace).
+     *
+     * @param context to encode into a valid header value.
+     * @return a valid W3C traceparent header value - empty if required IDs are missing or input is null.
+     */
+    @Override
+    public Optional<String> encode(PropagationContext context) {
+        // Check context is valid
+        if (context == null) {
+            return Optional.empty();
+        }
+
+        if (!W3CTraceIdProvider.isValidTraceId(context.getTraceId())) {
+            LOG.warn("Unable to encode TraceId to W3C format: {}", context.getTraceId());
+            return Optional.empty();
+        }
+
+        if (!W3CTraceIdProvider.isValidSpanId(context.getSpanId())) {
+            LOG.warn("Unable to encode SpanId to W3C format: {}", context.getSpanId());
+            return Optional.empty();
+        }
+
+        final StringBuilder builder = new StringBuilder(HEADER_LENGTH)
+            .append(DEFAULT_VERSION).append(SEGMENT_SEPARATOR)
+            .append(context.getTraceId()).append(SEGMENT_SEPARATOR)
+            .append(context.getSpanId()).append(SEGMENT_SEPARATOR)
+            .append(NOT_SAMPLED_TRACEFLAGS);
+
+        return Optional.of(builder.toString());
+    }
+}

--- a/beeline-core/src/test/java/io/honeycomb/beeline/tracing/propagation/W3CPropagationCodecTest.java
+++ b/beeline-core/src/test/java/io/honeycomb/beeline/tracing/propagation/W3CPropagationCodecTest.java
@@ -1,0 +1,127 @@
+package io.honeycomb.beeline.tracing.propagation;
+
+import org.junit.Before;
+import org.junit.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.util.Optional;
+
+public class W3CPropagationCodecTest {
+
+    private W3CPropagationCodec codec = W3CPropagationCodec.getInstance();
+
+    @Before
+    public void setUp() {
+        codec = new W3CPropagationCodec();
+    }
+
+    // Decode
+
+    @Test
+    public void GIVEN_aNullParameter_EXPECT_anEmptyContext() {
+        final PropagationContext context = codec.decode(null);
+
+        assertThat(context).isEqualTo(PropagationContext.emptyContext());
+    }
+
+    @Test
+    public void GIVEN_amEmptyParameter_EXPECT_anEmptyContext() {
+        final PropagationContext context = codec.decode("");
+
+        assertThat(context).isEqualTo(PropagationContext.emptyContext());
+    }
+
+    @Test
+    public void GIVEN_aValidTraceValue_EXPECT_toDecodeCorrectly() {
+        final String traceHeader = "00-4cbc8d50f02449e887e8bc2aa8020d26-ace1ecab581fc069-00";
+        final PropagationContext context = codec.decode(traceHeader);
+
+        assertThat(context.getTraceId()).isEqualTo("4cbc8d50f02449e887e8bc2aa8020d26");
+        assertThat(context.getSpanId()).isEqualTo("ace1ecab581fc069");
+        assertThat(context.getTraceFields().size()).isEqualTo(0);
+    }
+
+    @Test
+    public void GIVEN_aValidTraceValueWithSampledTraceFlag_EXPECT_toDecodeCorrectly() {
+        final String traceHeader = "00-4cbc8d50f02449e887e8bc2aa8020d26-ace1ecab581fc069-01";
+        final PropagationContext context = codec.decode(traceHeader);
+
+        assertThat(context.getTraceId()).isEqualTo("4cbc8d50f02449e887e8bc2aa8020d26");
+        assertThat(context.getSpanId()).isEqualTo("ace1ecab581fc069");
+        assertThat(context.getTraceFields().size()).isEqualTo(0);
+    }
+
+    @Test
+    public void GIVEN_aTraceHeaderTooFewSegments_EXPECT_anEmptyContext() {
+        final String traceHeader = "1-2-3";
+
+        final PropagationContext context = codec.decode(traceHeader);
+
+        assertThat(context).isEqualTo(PropagationContext.emptyContext());
+    }
+
+    @Test
+    public void GIVEN_aTraceHeaderTooManySegments_EXPECT_anEmptyContext() {
+        final String traceHeader = "1-2-3-4-5";
+
+        final PropagationContext context = codec.decode(traceHeader);
+
+        assertThat(context).isEqualTo(PropagationContext.emptyContext());
+    }
+
+
+    @Test
+    public void GIVEN_aTraceHeaderWithInvalidVersion_EXPECT_anEmptyContext() {
+        final String traceHeader = "invalid-4cbc8d50f02449e887e8bc2aa8020d26-ace1ecab581fc069-00";
+
+        final PropagationContext context = codec.decode(traceHeader);
+
+        assertThat(context).isEqualTo(PropagationContext.emptyContext());
+    }
+
+    @Test
+    public void GIVEN_aTraceHeaderWithInvalidTraceId_EXPECT_anEmptyContext() {
+        final String traceHeader = "00-invalid-ace1ecab581fc069-00";
+
+        final PropagationContext context = codec.decode(traceHeader);
+
+        assertThat(context).isEqualTo(PropagationContext.emptyContext());
+    }
+
+    @Test
+    public void GIVEN_aTraceHeaderWithInvalidSpanId_EXPECT_anEmptyContext() {
+        final String traceHeader = "00-4cbc8d50f02449e887e8bc2aa8020d26-invalid-00";
+
+        final PropagationContext context = codec.decode(traceHeader);
+
+        assertThat(context).isEqualTo(PropagationContext.emptyContext());
+    }
+
+    @Test
+    public void GIVEN_aTraceHeaderWithInvalidTraceFlags_EXPECT_anEmptyContext() {
+        final String traceHeader = "00-4cbc8d50f02449e887e8bc2aa8020d26-ace1ecab581fc069-invalid";
+
+        final PropagationContext context = codec.decode(traceHeader);
+
+        assertThat(context).isEqualTo(PropagationContext.emptyContext());
+    }
+
+    // Encode
+
+    @Test
+    public void GIVEN_anEmptyContext_EXPECT_empty() {
+        final Optional<String> encoded = codec.encode(PropagationContext.emptyContext());
+
+        assertThat(encoded).isEmpty();
+    }
+
+    @Test
+    public void GIVEN_aPopulatedContext_EXPECT_aValidHeaderValue() {
+        String traceId = "4cbc8d50f02449e887e8bc2aa8020d26";
+        String spanId = "ace1ecab581fc069";
+        final String encoded = codec.encode(new PropagationContext(traceId, spanId, null, null)).get();
+
+        assertThat(encoded).isEqualTo(String.join("-", "00", traceId, spanId, "00"));
+    }
+}


### PR DESCRIPTION
This change adds a W3C spec compatible PropagationCodec that is built on top of the W3C `traceparent` http header. This propagation codec does not support additional trace context provided by the `tracecontext` http header.

This change also extends the W3CTraceIdProvider to provide access methods for validating trace and span IDs.

~~__NOTE__: This PR is based on #50 and I'll leave this PR as draft until it has been merged. Please view [01df9345](https://github.com/honeycombio/beeline-java/commit/01df93452d0f57a67a1413c584b5a475083027ab) directly for just the changes for adding the W3C propagation codec.~~

#50 has now been merged.