### PR TITLE
Refactor propagator codec implementations to use map<string, string> for encode & decode

### DIFF
--- a/beeline-core/src/main/java/io/honeycomb/beeline/tracing/propagation/AWSPropagationCodec.java
+++ b/beeline-core/src/main/java/io/honeycomb/beeline/tracing/propagation/AWSPropagationCodec.java
@@ -17,12 +17,12 @@ import static io.honeycomb.libhoney.utils.ObjectUtils.isNullOrEmpty;
  * <h1>Thread-safety</h1>
  * Instances of this class are thread-safe and can be shared.
  */
-public class AWSPropagationCodec implements PropagationCodec<String> {
+public class AWSPropagationCodec implements PropagationCodec<Map<String, String>> {
 
     private static final AWSPropagationCodec INSTANCE = new AWSPropagationCodec();
 
     // @formatter:off
-    public static final String AWS_TRACE_HEADER             = "X-Amzn-Trace-Id";
+    protected static final String AWS_TRACE_HEADER          = "X-Amzn-Trace-Id";
 
     private static final String SEGMENT_SEPARATOR           = ";";
     private static final Pattern SPLIT_SEGMENTS_PATTERN     = Pattern.compile(SEGMENT_SEPARATOR);
@@ -57,7 +57,11 @@ public class AWSPropagationCodec implements PropagationCodec<String> {
      * @return extracted context - "empty" context if encodedTrace value has an invalid format or is null.
      */
     @Override
-    public PropagationContext decode(String encodedTrace) {
+    public PropagationContext decode(Map<String, String> headers) {
+        if (headers == null || !headers.containsKey(AWS_TRACE_HEADER)) {
+            return PropagationContext.emptyContext();
+        }
+        final String encodedTrace = headers.getOrDefault(AWSPropagationCodec.AWS_TRACE_HEADER, null);
         if (isNullOrEmpty(encodedTrace)) {
             return PropagationContext.emptyContext();
         }
@@ -100,7 +104,7 @@ public class AWSPropagationCodec implements PropagationCodec<String> {
      * @return a valid AWS http header value - empty if required IDs are missing or input is null.
      */
     @Override
-    public Optional<String> encode(PropagationContext context) {
+    public Optional<Map<String, String>> encode(PropagationContext context) {
         if (context == null || isNullOrEmpty(context.getSpanId()) || isNullOrEmpty(context.getTraceId())) {
             return Optional.empty();
         }
@@ -116,6 +120,8 @@ public class AWSPropagationCodec implements PropagationCodec<String> {
             }
         }
 
-        return Optional.of(builder.toString());
+        return Optional.of(
+            Map.of(AWS_TRACE_HEADER, builder.toString())
+        );
     }
 }

--- a/beeline-core/src/main/java/io/honeycomb/beeline/tracing/propagation/AWSPropagationCodec.java
+++ b/beeline-core/src/main/java/io/honeycomb/beeline/tracing/propagation/AWSPropagationCodec.java
@@ -1,5 +1,6 @@
 package io.honeycomb.beeline.tracing.propagation;
 
+import java.util.Collections;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.Optional;
@@ -120,8 +121,6 @@ public class AWSPropagationCodec implements PropagationCodec<Map<String, String>
             }
         }
 
-        return Optional.of(
-            Map.of(AWS_TRACE_HEADER, builder.toString())
-        );
+        return Optional.of(Collections.singletonMap(AWS_TRACE_HEADER, builder.toString()));
     }
 }

--- a/beeline-core/src/main/java/io/honeycomb/beeline/tracing/propagation/BeelineServletFilter.java
+++ b/beeline-core/src/main/java/io/honeycomb/beeline/tracing/propagation/BeelineServletFilter.java
@@ -19,6 +19,7 @@ import java.net.URI;
 import java.net.URISyntaxException;
 import java.util.*;
 import java.util.function.Function;
+import java.util.stream.Collectors;
 
 import static io.honeycomb.beeline.tracing.utils.TraceFieldConstants.REQUEST_ERROR_DETAIL_FIELD;
 import static io.honeycomb.beeline.tracing.utils.TraceFieldConstants.REQUEST_ERROR_FIELD;
@@ -482,6 +483,23 @@ public class BeelineServletFilter implements Filter {
         @Override
         public int getContentLength() {
             return request.getContentLength();
+        }
+
+        @Override
+        public Map<String, String> getHeaders() {
+            Map<String, String> headers = Map.of();
+            Enumeration<String> headerNames = request.getHeaderNames();
+
+            if (headerNames != null) {
+                return Collections.list(request.getHeaderNames())
+                    .stream()
+                    .collect(Collectors.toMap(
+                        Function.identity(),
+                        h -> request.getHeader(h)
+                    ));
+            }
+
+            return headers;
         }
     }
 

--- a/beeline-core/src/main/java/io/honeycomb/beeline/tracing/propagation/BeelineServletFilter.java
+++ b/beeline-core/src/main/java/io/honeycomb/beeline/tracing/propagation/BeelineServletFilter.java
@@ -487,7 +487,7 @@ public class BeelineServletFilter implements Filter {
 
         @Override
         public Map<String, String> getHeaders() {
-            Map<String, String> headers = Map.of();
+            Map<String, String> headers = Collections.emptyMap();
             Enumeration<String> headerNames = request.getHeaderNames();
 
             if (headerNames != null) {

--- a/beeline-core/src/main/java/io/honeycomb/beeline/tracing/propagation/HttpClientPropagator.java
+++ b/beeline-core/src/main/java/io/honeycomb/beeline/tracing/propagation/HttpClientPropagator.java
@@ -4,6 +4,7 @@ import io.honeycomb.beeline.tracing.Span;
 import io.honeycomb.beeline.tracing.Tracer;
 import io.honeycomb.libhoney.shaded.org.apache.http.HttpHeaders;
 
+import java.util.Map;
 import java.util.function.Function;
 
 import static io.honeycomb.beeline.tracing.utils.TraceFieldConstants.*;
@@ -36,7 +37,7 @@ public class HttpClientPropagator {
     public static final String HTTP_CLIENT_SPAN_TYPE = "http_client";
 
     private final Tracer tracer;
-    private final PropagationCodec<String> propagationCodec;
+    private final PropagationCodec<Map<String, String>> propagationCodec;
     private final Function<HttpClientRequestAdapter, String> requestToSpanName;
 
     /**
@@ -54,7 +55,7 @@ public class HttpClientPropagator {
 
     //Exposed for unit testing
     protected HttpClientPropagator(final Tracer tracer,
-                                   final PropagationCodec<String> propagationCodec,
+                                   final PropagationCodec<Map<String, String>> propagationCodec,
                                    final Function<HttpClientRequestAdapter, String> requestToSpanName) {
         this.tracer = tracer;
         this.propagationCodec = propagationCodec;
@@ -109,8 +110,8 @@ public class HttpClientPropagator {
 
     private void propagateTrace(final HttpClientRequestAdapter httpRequest, final Span childSpan) {
         propagationCodec.encode(childSpan.getTraceContext())
-            .ifPresent(headerValue ->
-                httpRequest.addHeader(HttpHeaderV1PropagationCodec.HONEYCOMB_TRACE_HEADER, headerValue)
+            .ifPresent(headers ->
+                headers.forEach((k,v) -> httpRequest.addHeader(k, v))
             );
     }
 

--- a/beeline-core/src/main/java/io/honeycomb/beeline/tracing/propagation/HttpClientRequestAdapter.java
+++ b/beeline-core/src/main/java/io/honeycomb/beeline/tracing/propagation/HttpClientRequestAdapter.java
@@ -6,7 +6,7 @@ import java.util.Optional;
  * Adapt an HTTP request that is about to be sent by a client. This is so it can be
  * processed by an {@link HttpClientPropagator}.
  */
-public interface HttpClientRequestAdapter {
+public interface HttpClientRequestAdapter extends HttpRequestAdapter {
     /**
      * Returns the HTTP method of the request.
      * @return the HTTP method

--- a/beeline-core/src/main/java/io/honeycomb/beeline/tracing/propagation/HttpHeaderV1PropagationCodec.java
+++ b/beeline-core/src/main/java/io/honeycomb/beeline/tracing/propagation/HttpHeaderV1PropagationCodec.java
@@ -182,9 +182,7 @@ public class HttpHeaderV1PropagationCodec implements PropagationCodec<Map<String
         }
 
         final StringBuilder stringBuilder = buildString(context, contextAsB64);
-        return Optional.of(
-            Map.of(HONEYCOMB_TRACE_HEADER, stringBuilder.toString())
-        );
+        return Optional.of(Collections.singletonMap(HONEYCOMB_TRACE_HEADER, stringBuilder.toString()));
     }
 
     /**

--- a/beeline-core/src/main/java/io/honeycomb/beeline/tracing/propagation/HttpRequestAdapter.java
+++ b/beeline-core/src/main/java/io/honeycomb/beeline/tracing/propagation/HttpRequestAdapter.java
@@ -1,0 +1,9 @@
+package io.honeycomb.beeline.tracing.propagation;
+
+import java.util.Map;
+
+public interface HttpRequestAdapter {
+
+    public Map<String, String> getHeaders();
+
+}

--- a/beeline-core/src/main/java/io/honeycomb/beeline/tracing/propagation/HttpServerPropagator.java
+++ b/beeline-core/src/main/java/io/honeycomb/beeline/tracing/propagation/HttpServerPropagator.java
@@ -4,6 +4,7 @@ import io.honeycomb.beeline.tracing.Beeline;
 import io.honeycomb.beeline.tracing.Span;
 import io.honeycomb.libhoney.shaded.org.apache.http.HttpHeaders;
 
+import java.util.Map;
 import java.util.function.Function;
 
 import static io.honeycomb.beeline.tracing.propagation.HttpHeaderV1PropagationCodec.HONEYCOMB_TRACE_HEADER;
@@ -39,7 +40,7 @@ public class HttpServerPropagator {
     private final Function<HttpServerRequestAdapter, String> requestToSpanName;
     private final String serviceName;
     private final HttpServerRequestSpanCustomizer spanCustomizer;
-    private final PropagationCodec<String> propagationCodec;
+    private final PropagationCodec<Map<String, String>> propagationCodec;
     private final Beeline beeline;
 
     /**
@@ -62,7 +63,7 @@ public class HttpServerPropagator {
     protected HttpServerPropagator(final String serviceName,
                                 final Function<HttpServerRequestAdapter, String> requestToSpanName,
                                 final HttpServerRequestSpanCustomizer spanCustomizer,
-                                final PropagationCodec<String> propagationCodec,
+                                final PropagationCodec<Map<String, String>> propagationCodec,
                                 final Beeline beeline) {
         this.requestToSpanName = requestToSpanName;
         this.serviceName = serviceName;
@@ -78,9 +79,8 @@ public class HttpServerPropagator {
      * @return the span
      */
     public Span startPropagation(final HttpServerRequestAdapter httpRequest) {
-        final String honeycombHeaderValue = httpRequest.getFirstHeader(HONEYCOMB_TRACE_HEADER).orElse(null);
         //PropagationCodec#decode is null-safe
-        final PropagationContext decoded = propagationCodec.decode(honeycombHeaderValue);
+        final PropagationContext decoded = propagationCodec.decode(httpRequest.getHeaders());
 
         final String spanName = requestToSpanName.apply(httpRequest);
 

--- a/beeline-core/src/main/java/io/honeycomb/beeline/tracing/propagation/HttpServerRequestAdapter.java
+++ b/beeline-core/src/main/java/io/honeycomb/beeline/tracing/propagation/HttpServerRequestAdapter.java
@@ -8,7 +8,7 @@ import java.util.Optional;
  * Adapt an HTTP request that has been received by a server. This is so it can be
  * processed by an {@link HttpServerPropagator}.
  */
-public interface HttpServerRequestAdapter {
+public interface HttpServerRequestAdapter extends HttpRequestAdapter {
     /**
      * Returns the HTTP method of the request.
      * @return the HTTP method

--- a/beeline-core/src/main/java/io/honeycomb/beeline/tracing/propagation/Propagation.java
+++ b/beeline-core/src/main/java/io/honeycomb/beeline/tracing/propagation/Propagation.java
@@ -1,9 +1,12 @@
 package io.honeycomb.beeline.tracing.propagation;
 
+import java.util.Map;
+
 /**
  * Contains helpers for propagation of trace data.
  * <p>
  * For example, decode trace data received over the wire and start a trace:
+ *
  * <pre>
  * PropagationContext context = Propagation.honeycombHeaderV1().decode(traceHeader);
  * tracer.startTrace("customer-db", "get-customer-data", context);
@@ -19,7 +22,7 @@ public final class Propagation {
      *
      * @return a codec.
      */
-    public static PropagationCodec<String> honeycombHeaderV1() {
+    public static PropagationCodec<Map<String,String>> honeycombHeaderV1() {
         return HttpHeaderV1PropagationCodec.getInstance();
     }
 
@@ -28,7 +31,7 @@ public final class Propagation {
      *
      * @return a codec.
      */
-    public static PropagationCodec<String> aws() {
+    public static PropagationCodec<Map<String,String>> aws() {
         return AWSPropagationCodec.getInstance();
     }
 
@@ -37,7 +40,7 @@ public final class Propagation {
      *
      * @return a codec.
      */
-    public static PropagationCodec<String> w3c() {
+    public static PropagationCodec<Map<String,String>> w3c() {
         return HttpHeaderV1PropagationCodec.getInstance();
     }
 }

--- a/beeline-core/src/main/java/io/honeycomb/beeline/tracing/propagation/W3CPropagationCodec.java
+++ b/beeline-core/src/main/java/io/honeycomb/beeline/tracing/propagation/W3CPropagationCodec.java
@@ -1,5 +1,6 @@
 package io.honeycomb.beeline.tracing.propagation;
 
+import java.util.Collections;
 import java.util.Map;
 import java.util.Optional;
 import java.util.regex.Pattern;
@@ -130,8 +131,6 @@ public class W3CPropagationCodec implements PropagationCodec<Map<String, String>
             .append(context.getSpanId()).append(SEGMENT_SEPARATOR)
             .append(NOT_SAMPLED_TRACEFLAGS);
 
-        return Optional.of(
-            Map.of(W3C_TRACEPARENT_HEADER, builder.toString())
-        );
+        return Optional.of(Collections.singletonMap(W3C_TRACEPARENT_HEADER, builder.toString()));
     }
 }

--- a/beeline-core/src/test/java/io/honeycomb/beeline/tracing/propagation/AWSPropagationCodecTest.java
+++ b/beeline-core/src/test/java/io/honeycomb/beeline/tracing/propagation/AWSPropagationCodecTest.java
@@ -33,7 +33,7 @@ public class AWSPropagationCodecTest {
 
     @Test
     public void GIVEN_amEmptyParameter_EXPECT_anEmptyContext() {
-        final PropagationContext context = codec.decode(Map.of("", ""));
+        final PropagationContext context = codec.decode(Collections.singletonMap("", ""));
 
         assertThat(context).isEqualTo(PropagationContext.emptyContext());
     }
@@ -41,7 +41,7 @@ public class AWSPropagationCodecTest {
     @Test
     public void GIVEN_aValidTraceValue_EXPECT_toDecodeCorrectly() {
         final String traceHeader = "root=123;parent=abc;foo=bar;userId=123;toRetry=true";
-        final PropagationContext context = codec.decode(Map.of(AWSPropagationCodec.AWS_TRACE_HEADER, traceHeader));
+        final PropagationContext context = codec.decode(Collections.singletonMap(AWSPropagationCodec.AWS_TRACE_HEADER, traceHeader));
 
         assertThat(context.getTraceId()).isEqualTo("123");
         assertThat(context.getSpanId()).isEqualTo("abc");
@@ -54,7 +54,7 @@ public class AWSPropagationCodecTest {
     @Test
     public void GIVEN_aValidTraceValueWithSelf_EXPECT_toDecodeCorrectly() {
         final String traceHeader = "root=123;self=abc;foo=bar;userId=123;toRetry=true";
-        final PropagationContext context = codec.decode(Map.of(AWSPropagationCodec.AWS_TRACE_HEADER, traceHeader));
+        final PropagationContext context = codec.decode(Collections.singletonMap(AWSPropagationCodec.AWS_TRACE_HEADER, traceHeader));
 
         assertThat(context.getTraceId()).isEqualTo("123");
         assertThat(context.getSpanId()).isEqualTo("abc");
@@ -67,7 +67,7 @@ public class AWSPropagationCodecTest {
     @Test
     public void GIVEN_aValidTraceValueWithMixedCasing_EXPECT_toDecodeCorrectly() {
         final String traceHeader = "rOoT=123;PaReNt=abc;foo=bar;userId=123;toRetry=true";
-        final PropagationContext context = codec.decode(Map.of(AWSPropagationCodec.AWS_TRACE_HEADER, traceHeader));
+        final PropagationContext context = codec.decode(Collections.singletonMap(AWSPropagationCodec.AWS_TRACE_HEADER, traceHeader));
 
         assertThat(context.getTraceId()).isEqualTo("123");
         assertThat(context.getSpanId()).isEqualTo("abc");
@@ -80,7 +80,7 @@ public class AWSPropagationCodecTest {
     @Test
     public void GIVEN_aValidTraceValueWithSelfAndMixedCasing_EXPECT_toDecodeCorrectly() {
         final String traceHeader = "rOoT=123;sElF=abc;foo=bar;userId=123;toRetry=true";
-        final PropagationContext context = codec.decode(Map.of(AWSPropagationCodec.AWS_TRACE_HEADER, traceHeader));
+        final PropagationContext context = codec.decode(Collections.singletonMap(AWSPropagationCodec.AWS_TRACE_HEADER, traceHeader));
 
         assertThat(context.getTraceId()).isEqualTo("123");
         assertThat(context.getSpanId()).isEqualTo("abc");
@@ -93,7 +93,7 @@ public class AWSPropagationCodecTest {
     @Test
     public void GIVEN_aTraceHeaderWhereKVsareInReverseOrder_EXPECT_toDecodeCorrectly() {
         final String traceHeader = "foo=bar;userId=123;toRetry=true;parent=abc;root=123";
-        final PropagationContext context = codec.decode(Map.of(AWSPropagationCodec.AWS_TRACE_HEADER, traceHeader));
+        final PropagationContext context = codec.decode(Collections.singletonMap(AWSPropagationCodec.AWS_TRACE_HEADER, traceHeader));
 
         assertThat(context.getTraceId()).isEqualTo("123");
         assertThat(context.getSpanId()).isEqualTo("abc");
@@ -106,7 +106,7 @@ public class AWSPropagationCodecTest {
     @Test
     public void GIVEN_aTraceHeaderWithSelfParentRoot_EXPECT_toDecodeCorrectlyWithLastValueWins() {
         final String traceHeader = "root=123;parent=abc;self=baz";
-        final PropagationContext context = codec.decode(Map.of(AWSPropagationCodec.AWS_TRACE_HEADER, traceHeader));
+        final PropagationContext context = codec.decode(Collections.singletonMap(AWSPropagationCodec.AWS_TRACE_HEADER, traceHeader));
 
         assertThat(context.getTraceId()).isEqualTo("123");
         assertThat(context.getSpanId()).isEqualTo("baz");
@@ -116,7 +116,7 @@ public class AWSPropagationCodecTest {
     @Test
     public void GIVEN_aTraceHeaderWithSelfRootParent_EXPECT_toDecodeCorrectlyWithLastValueWins() {
         final String traceHeader = "root=123;self=baz;parent=abc;";
-        final PropagationContext context = codec.decode(Map.of(AWSPropagationCodec.AWS_TRACE_HEADER, traceHeader));
+        final PropagationContext context = codec.decode(Collections.singletonMap(AWSPropagationCodec.AWS_TRACE_HEADER, traceHeader));
 
         assertThat(context.getTraceId()).isEqualTo("123");
         assertThat(context.getSpanId()).isEqualTo("abc");
@@ -126,7 +126,7 @@ public class AWSPropagationCodecTest {
     @Test
     public void GIVEN_aTraceHeaderWithoutParentOrSelf_EXPECT_toDecodeCorrectlySpanIdAsTraceId() {
         final String traceHeader = "root=123";
-        final PropagationContext context = codec.decode(Map.of(AWSPropagationCodec.AWS_TRACE_HEADER, traceHeader));
+        final PropagationContext context = codec.decode(Collections.singletonMap(AWSPropagationCodec.AWS_TRACE_HEADER, traceHeader));
 
         assertThat(context.getTraceId()).isEqualTo("123");
         assertThat(context.getSpanId()).isEqualTo("123");
@@ -145,6 +145,6 @@ public class AWSPropagationCodecTest {
     public void GIVEN_aPopulatedContext_EXPECT_aValidHeaderValue() {
         final Map<String, String> encoded = codec.encode(new PropagationContext("123", "abc", null, Collections.singletonMap("test", "value"))).get();
 
-        assertThat(encoded).isEqualTo(Map.of(AWSPropagationCodec.AWS_TRACE_HEADER, "root=123;parent=abc;test=value"));
+        assertThat(encoded).isEqualTo(Collections.singletonMap(AWSPropagationCodec.AWS_TRACE_HEADER, "root=123;parent=abc;test=value"));
     }
 }

--- a/beeline-core/src/test/java/io/honeycomb/beeline/tracing/propagation/BeelineServletFilterTest.java
+++ b/beeline-core/src/test/java/io/honeycomb/beeline/tracing/propagation/BeelineServletFilterTest.java
@@ -303,10 +303,11 @@ public class BeelineServletFilterTest {
         final String traceId = "current-trace-1";
         final String parentId = "parent-span-1";
         final PropagationContext context = new PropagationContext(traceId, parentId, null, Collections.singletonMap("trace-field", "abc"));
-        final String headerValue = Propagation.honeycombHeaderV1()
+        final Map<String, String> headers = Propagation.honeycombHeaderV1()
                                         .encode(context)
                                         .orElseThrow(() -> new  AssertionError("Propagation context test setup errored"));
 
+        final String headerValue = headers.get(HONEYCOMB_TRACE_HEADER);
         given().header(HONEYCOMB_TRACE_HEADER, headerValue).when().get(fullPath(HELLO_PATH)).then().assertThat().statusCode(200);
         verify(mockTransport).submit(resolvedEventCaptor.capture());
         final ResolvedEvent resolvedEvent = resolvedEventCaptor.getValue();

--- a/beeline-core/src/test/java/io/honeycomb/beeline/tracing/propagation/HttpClientPropagatorTest.java
+++ b/beeline-core/src/test/java/io/honeycomb/beeline/tracing/propagation/HttpClientPropagatorTest.java
@@ -9,6 +9,7 @@ import org.junit.runner.RunWith;
 import org.mockito.Mock;
 import org.mockito.junit.MockitoJUnitRunner;
 
+import java.util.Collections;
 import java.util.Map;
 import java.util.Optional;
 
@@ -43,7 +44,7 @@ public class HttpClientPropagatorTest {
     @Test
     public void whenStartPropagation_traceHeaderIsAdded_onlyRequiredSpanFieldsAreAdded() {
         when(mockTracer.startChildSpan(EXPECTED_SPAN_NAME)).thenReturn(mockSpan);
-        when(mockPropagationCodec.encode(any())).thenReturn(Optional.of(Map.of(HttpHeaderV1PropagationCodec.HONEYCOMB_TRACE_HEADER, EXPECTED_TRACE_HEADER)));
+        when(mockPropagationCodec.encode(any())).thenReturn(Optional.of(Collections.singletonMap(HttpHeaderV1PropagationCodec.HONEYCOMB_TRACE_HEADER, EXPECTED_TRACE_HEADER)));
         final String expectedHttpMethod = "httpMethod1";
         when(mockHttpRequest.getMethod()).thenReturn(expectedHttpMethod);
 
@@ -58,7 +59,7 @@ public class HttpClientPropagatorTest {
     @Test
     public void whenStartPropagation_withAdditionalData_optionalSpanFieldsAreAdded_traceHeaderIsAdded() {
         when(mockTracer.startChildSpan(EXPECTED_SPAN_NAME)).thenReturn(mockSpan);
-        when(mockPropagationCodec.encode(any())).thenReturn(Optional.of(Map.of(HttpHeaderV1PropagationCodec.HONEYCOMB_TRACE_HEADER, EXPECTED_TRACE_HEADER)));
+        when(mockPropagationCodec.encode(any())).thenReturn(Optional.of(Collections.singletonMap(HttpHeaderV1PropagationCodec.HONEYCOMB_TRACE_HEADER, EXPECTED_TRACE_HEADER)));
         final String expectedHttpMethod = "httpMethod1";
         when(mockHttpRequest.getMethod()).thenReturn(expectedHttpMethod);
         final String expectedPath = "expectedPath";

--- a/beeline-core/src/test/java/io/honeycomb/beeline/tracing/propagation/HttpClientPropagatorTest.java
+++ b/beeline-core/src/test/java/io/honeycomb/beeline/tracing/propagation/HttpClientPropagatorTest.java
@@ -9,6 +9,7 @@ import org.junit.runner.RunWith;
 import org.mockito.Mock;
 import org.mockito.junit.MockitoJUnitRunner;
 
+import java.util.Map;
 import java.util.Optional;
 
 import static io.honeycomb.beeline.tracing.propagation.MockSpanUtils.stubFluentCalls;
@@ -29,7 +30,7 @@ public class HttpClientPropagatorTest {
     @Mock
     private HttpClientResponseAdapter mockHttpResponse;
     @Mock
-    private PropagationCodec<String> mockPropagationCodec;
+    private PropagationCodec<Map<String, String>> mockPropagationCodec;
 
     private HttpClientPropagator httpClientPropagator;
 
@@ -42,7 +43,7 @@ public class HttpClientPropagatorTest {
     @Test
     public void whenStartPropagation_traceHeaderIsAdded_onlyRequiredSpanFieldsAreAdded() {
         when(mockTracer.startChildSpan(EXPECTED_SPAN_NAME)).thenReturn(mockSpan);
-        when(mockPropagationCodec.encode(any())).thenReturn(Optional.of(EXPECTED_TRACE_HEADER));
+        when(mockPropagationCodec.encode(any())).thenReturn(Optional.of(Map.of(HttpHeaderV1PropagationCodec.HONEYCOMB_TRACE_HEADER, EXPECTED_TRACE_HEADER)));
         final String expectedHttpMethod = "httpMethod1";
         when(mockHttpRequest.getMethod()).thenReturn(expectedHttpMethod);
 
@@ -57,7 +58,7 @@ public class HttpClientPropagatorTest {
     @Test
     public void whenStartPropagation_withAdditionalData_optionalSpanFieldsAreAdded_traceHeaderIsAdded() {
         when(mockTracer.startChildSpan(EXPECTED_SPAN_NAME)).thenReturn(mockSpan);
-        when(mockPropagationCodec.encode(any())).thenReturn(Optional.of(EXPECTED_TRACE_HEADER));
+        when(mockPropagationCodec.encode(any())).thenReturn(Optional.of(Map.of(HttpHeaderV1PropagationCodec.HONEYCOMB_TRACE_HEADER, EXPECTED_TRACE_HEADER)));
         final String expectedHttpMethod = "httpMethod1";
         when(mockHttpRequest.getMethod()).thenReturn(expectedHttpMethod);
         final String expectedPath = "expectedPath";

--- a/beeline-core/src/test/java/io/honeycomb/beeline/tracing/propagation/HttpHeaderV1PropagationCodecTest.java
+++ b/beeline-core/src/test/java/io/honeycomb/beeline/tracing/propagation/HttpHeaderV1PropagationCodecTest.java
@@ -38,7 +38,7 @@ public class HttpHeaderV1PropagationCodecTest {
         final String jsonAsBase64 = Base64.encodeBase64String(jsonString.getBytes(UTF_8));
         final String traceHeader = "1;trace_id=123,parent_id=abc,dataset=hellodataset,context=" + jsonAsBase64;
 
-        final PropagationContext decode = codec.decode(traceHeader);
+        final PropagationContext decode = codec.decode(Map.of(HttpHeaderV1PropagationCodec.HONEYCOMB_TRACE_HEADER, traceHeader));
 
         assertThat(decode.getSpanId()).isEqualTo("abc");
         assertThat(decode.getTraceId()).isEqualTo("123");
@@ -52,7 +52,7 @@ public class HttpHeaderV1PropagationCodecTest {
         final String jsonAsBase64 = Base64.encodeBase64String(jsonString.getBytes(UTF_8));
         final String traceHeader = "1;context=" + jsonAsBase64 + ",dataset=hellodataset,parent_id=abc,trace_id=123";
 
-        final PropagationContext decode = codec.decode(traceHeader);
+        final PropagationContext decode = codec.decode(Map.of(HttpHeaderV1PropagationCodec.HONEYCOMB_TRACE_HEADER, traceHeader));
 
         assertThat(decode.getSpanId()).isEqualTo("abc");
         assertThat(decode.getTraceId()).isEqualTo("123");
@@ -66,7 +66,7 @@ public class HttpHeaderV1PropagationCodecTest {
         final String jsonAsBase64 = Base64.encodeBase64String(jsonString.getBytes(UTF_8));
         final String traceHeader = "1;trace_id=beef-patty,parent_id=turkey_roast,context=" + jsonAsBase64;
 
-        final PropagationContext decode = codec.decode(traceHeader);
+        final PropagationContext decode = codec.decode(Map.of(HttpHeaderV1PropagationCodec.HONEYCOMB_TRACE_HEADER, traceHeader));
 
         assertThat(decode.getSpanId()).isEqualTo("turkey_roast");
         assertThat(decode.getTraceId()).isEqualTo("beef-patty");
@@ -80,7 +80,7 @@ public class HttpHeaderV1PropagationCodecTest {
     public void GIVEN_aValidTraceThatHasAContextOfNull_EXPECT_toDecodeCorrectly() {
         final String traceHeader = "1;trace_id=123,parent_id=abc,context=" + null;
 
-        final PropagationContext decode = codec.decode(traceHeader);
+        final PropagationContext decode = codec.decode(Map.of(HttpHeaderV1PropagationCodec.HONEYCOMB_TRACE_HEADER, traceHeader));
 
         assertThat(decode.getSpanId()).isEqualTo("abc");
         assertThat(decode.getTraceId()).isEqualTo("123");
@@ -91,7 +91,7 @@ public class HttpHeaderV1PropagationCodecTest {
     public void GIVEN_aValidTraceThatHasAMissingDataset_EXPECT_datasetToBeNull() {
         final String traceHeader = "1;trace_id=123,parent_id=abc";
 
-        final PropagationContext decode = codec.decode(traceHeader);
+        final PropagationContext decode = codec.decode(Map.of(HttpHeaderV1PropagationCodec.HONEYCOMB_TRACE_HEADER, traceHeader));
 
         assertThat(decode.getDataset()).isEqualTo(null);
     }
@@ -100,7 +100,7 @@ public class HttpHeaderV1PropagationCodecTest {
     public void GIVEN_aValidTraceThatHasAnEncodedDataset_EXPECT_datasetToBeDecoded() {
         final String traceHeader = "1;trace_id=123,parent_id=abc,dataset=%2Fhello+world";
 
-        final PropagationContext decode = codec.decode(traceHeader);
+        final PropagationContext decode = codec.decode(Map.of(HttpHeaderV1PropagationCodec.HONEYCOMB_TRACE_HEADER, traceHeader));
 
         assertThat(decode.getDataset()).isEqualTo("/hello world");
     }
@@ -109,7 +109,7 @@ public class HttpHeaderV1PropagationCodecTest {
     public void GIVEN_aTraceHeaderMissingParentID_EXPECT_emptyContext() {
         final String traceHeader = "1;trace_id=123";
 
-        final PropagationContext decode = codec.decode(traceHeader);
+        final PropagationContext decode = codec.decode(Map.of(HttpHeaderV1PropagationCodec.HONEYCOMB_TRACE_HEADER, traceHeader));
 
         assertThat(decode).isEqualTo(PropagationContext.emptyContext());
     }
@@ -118,7 +118,7 @@ public class HttpHeaderV1PropagationCodecTest {
     public void GIVEN_aTraceHeaderMissingTraceID_EXPECT_emptyContext() {
         final String traceHeader = "1;parent_id=123";
 
-        final PropagationContext decode = codec.decode(traceHeader);
+        final PropagationContext decode = codec.decode(Map.of(HttpHeaderV1PropagationCodec.HONEYCOMB_TRACE_HEADER, traceHeader));
 
         assertThat(decode).isEqualTo(PropagationContext.emptyContext());
     }
@@ -127,7 +127,7 @@ public class HttpHeaderV1PropagationCodecTest {
     public void GIVEN_aTraceHeaderThePayloadPart_EXPECT_emptyContext() {
         final String traceHeader = "1;";
 
-        final PropagationContext decode = codec.decode(traceHeader);
+        final PropagationContext decode = codec.decode(Map.of(HttpHeaderV1PropagationCodec.HONEYCOMB_TRACE_HEADER, traceHeader));
 
         assertThat(decode).isEqualTo(PropagationContext.emptyContext());
     }
@@ -136,7 +136,7 @@ public class HttpHeaderV1PropagationCodecTest {
     public void GIVEN_aValidTraceThatOmitsTraceFields_EXPECT_toDecodeCorrectly() {
         final String traceHeader = "1;trace_id=123,parent_id=abc";
 
-        final PropagationContext decode = codec.decode(traceHeader);
+        final PropagationContext decode = codec.decode(Map.of(HttpHeaderV1PropagationCodec.HONEYCOMB_TRACE_HEADER, traceHeader));
 
         assertThat(decode.getSpanId()).isEqualTo("abc");
         assertThat(decode.getTraceId()).isEqualTo("123");
@@ -152,7 +152,7 @@ public class HttpHeaderV1PropagationCodecTest {
         final JsonDeserializer deserializer = mock(JsonDeserializer.class);
         codec = new HttpHeaderV1PropagationCodec(serializer, deserializer);
 
-        codec.decode(traceHeader);
+        codec.decode(Map.of(HttpHeaderV1PropagationCodec.HONEYCOMB_TRACE_HEADER, traceHeader));
 
         verify(deserializer).deserialize(jsonString.getBytes("utf-8"));
         verifyZeroInteractions(serializer);
@@ -164,7 +164,7 @@ public class HttpHeaderV1PropagationCodecTest {
         final String jsonAsBase64 = Base64.encodeBase64String(jsonString.getBytes(UTF_8));
         final String traceHeader = "1;christmas_food=mince_pie,trace_id=123,parent_id=abc,context=" + jsonAsBase64;
 
-        final PropagationContext decode = codec.decode(traceHeader);
+        final PropagationContext decode = codec.decode(Map.of(HttpHeaderV1PropagationCodec.HONEYCOMB_TRACE_HEADER, traceHeader));
 
         assertThat(decode.getSpanId()).isEqualTo("abc");
         assertThat(decode.getTraceId()).isEqualTo("123");
@@ -173,7 +173,7 @@ public class HttpHeaderV1PropagationCodecTest {
 
     @Test
     public void GIVEN_amEmptyParameter_EXPECT_anEmptyContext() {
-        final PropagationContext decode = codec.decode("");
+        final PropagationContext decode = codec.decode(Map.of(HttpHeaderV1PropagationCodec.HONEYCOMB_TRACE_HEADER, ""));
 
         assertThat(decode).isEqualTo(PropagationContext.emptyContext());
     }
@@ -191,7 +191,7 @@ public class HttpHeaderV1PropagationCodecTest {
         final String jsonAsBase64 = Base64.encodeBase64String(jsonString.getBytes(UTF_8));
         final String traceHeader = "1;parent_id=abc,context=" + jsonAsBase64;
 
-        final PropagationContext decode = codec.decode(traceHeader);
+        final PropagationContext decode = codec.decode(Map.of(HttpHeaderV1PropagationCodec.HONEYCOMB_TRACE_HEADER, traceHeader));
 
         assertThat(decode).isEqualTo(PropagationContext.emptyContext());
     }
@@ -202,7 +202,7 @@ public class HttpHeaderV1PropagationCodecTest {
         final String jsonAsBase64 = Base64.encodeBase64String(jsonString.getBytes(UTF_8));
         final String traceHeader = "1;trace_id=abc,context=" + jsonAsBase64;
 
-        final PropagationContext decode = codec.decode(traceHeader);
+        final PropagationContext decode = codec.decode(Map.of(HttpHeaderV1PropagationCodec.HONEYCOMB_TRACE_HEADER, traceHeader));
 
         assertThat(decode).isEqualTo(PropagationContext.emptyContext());
     }
@@ -214,7 +214,7 @@ public class HttpHeaderV1PropagationCodecTest {
         final String versionString = "2";
         final String traceHeader = versionString + ";parent_id=123,trace_id=abc,context=" + jsonAsBase64;
 
-        final PropagationContext decode = codec.decode(traceHeader);
+        final PropagationContext decode = codec.decode(Map.of(HttpHeaderV1PropagationCodec.HONEYCOMB_TRACE_HEADER, traceHeader));
 
         assertThat(decode).isEqualTo(PropagationContext.emptyContext());
     }
@@ -226,7 +226,7 @@ public class HttpHeaderV1PropagationCodecTest {
         // wrong separator between the version and payload:
         final String traceHeader = "1,parent_id=123,trace_id=abc,context=" + jsonAsBase64;
 
-        final PropagationContext decode = codec.decode(traceHeader);
+        final PropagationContext decode = codec.decode(Map.of(HttpHeaderV1PropagationCodec.HONEYCOMB_TRACE_HEADER, traceHeader));
 
         assertThat(decode).isEqualTo(PropagationContext.emptyContext());
     }
@@ -238,7 +238,7 @@ public class HttpHeaderV1PropagationCodecTest {
         // wrong separator between the version and payload:
         final String traceHeader = "1;parent_id=123,trace_id=abc,context=" + jsonAsBase64;
 
-        final PropagationContext decode = codec.decode(traceHeader);
+        final PropagationContext decode = codec.decode(Map.of(HttpHeaderV1PropagationCodec.HONEYCOMB_TRACE_HEADER, traceHeader));
 
         assertThat(decode.getSpanId()).isEqualTo("123");
         assertThat(decode.getTraceId()).isEqualTo("abc");
@@ -252,7 +252,7 @@ public class HttpHeaderV1PropagationCodecTest {
         // wrong separator between the version and payload:
         final String traceHeader = "1;parent_id=123,trace_id=abc,context=" + "$" + jsonAsBase64;
 
-        final PropagationContext decode = codec.decode(traceHeader);
+        final PropagationContext decode = codec.decode(Map.of(HttpHeaderV1PropagationCodec.HONEYCOMB_TRACE_HEADER, traceHeader));
 
         assertThat(decode.getSpanId()).isEqualTo("123");
         assertThat(decode.getTraceId()).isEqualTo("abc");
@@ -261,59 +261,71 @@ public class HttpHeaderV1PropagationCodecTest {
 
     @Test
     public void GIVEN_anEmptyContext_EXPECT_empty() {
-        final Optional<String> encoded = codec.encode(PropagationContext.emptyContext());
+        final Optional<Map<String, String>> encoded = codec.encode(PropagationContext.emptyContext());
 
         assertThat(encoded).isEmpty();
     }
 
     @Test
     public void GIVEN_aMissingIds_EXPECT_empty() {
-        final Optional<String> encoded = codec.encode(new PropagationContext("", "", "", Collections.singletonMap("key", "value")));
+        final Optional<Map<String, String>> encoded = codec.encode(new PropagationContext("", "", "", Collections.singletonMap("key", "value")));
 
         assertThat(encoded).isEmpty();
     }
 
     @Test
     public void GIVEN_aPopulatedContext_EXPECT_aValidHeaderValue() {
-        final String encoded = codec.encode(new PropagationContext("abc", "123", "myDataset", Collections.singletonMap("key", "value"))).get();
+        final Map<String, String> encoded = codec.encode(new PropagationContext("abc", "123", "myDataset", Collections.singletonMap("key", "value"))).get();
 
-        assertThat(encoded).isEqualTo("1;trace_id=abc,parent_id=123,dataset=myDataset,context=" + Base64.encodeBase64String("{\"key\":\"value\"}".getBytes(UTF_8)));
+        assertThat(encoded).isEqualTo(
+            Map.of(HttpHeaderV1PropagationCodec.HONEYCOMB_TRACE_HEADER, "1;trace_id=abc,parent_id=123,dataset=myDataset,context=" + Base64.encodeBase64String("{\"key\":\"value\"}".getBytes(UTF_8)))
+        );
     }
 
     @Test
     public void GIVEN_aContextWithADataset_EXPECT_datasetStringToBeEncoded() {
-        final String encoded = codec.encode(new PropagationContext("abc", "123", "/hello world", Collections.singletonMap("key", "value"))).get();
+        final Map<String, String> encoded = codec.encode(new PropagationContext("abc", "123", "/hello world", Collections.singletonMap("key", "value"))).get();
 
-        assertThat(encoded).isEqualTo("1;trace_id=abc,parent_id=123,dataset=%2Fhello+world,context=" + Base64.encodeBase64String("{\"key\":\"value\"}".getBytes(UTF_8)));
+        assertThat(encoded).isEqualTo(
+            Map.of(HttpHeaderV1PropagationCodec.HONEYCOMB_TRACE_HEADER, "1;trace_id=abc,parent_id=123,dataset=%2Fhello+world,context=" + Base64.encodeBase64String("{\"key\":\"value\"}".getBytes(UTF_8)))
+        );
     }
 
 
     @Test
     public void GIVEN_aPopulatedContextWithoutADataset_EXPECT_aValidHeaderValue() {
-        final String encoded = codec.encode(new PropagationContext("abc", "123", null, Collections.singletonMap("key", "value"))).get();
+        final Map<String, String> encoded = codec.encode(new PropagationContext("abc", "123", null, Collections.singletonMap("key", "value"))).get();
 
-        assertThat(encoded).isEqualTo("1;trace_id=abc,parent_id=123,context=" + Base64.encodeBase64String("{\"key\":\"value\"}".getBytes(UTF_8)));
+        assertThat(encoded).isEqualTo(
+            Map.of(HttpHeaderV1PropagationCodec.HONEYCOMB_TRACE_HEADER, "1;trace_id=abc,parent_id=123,context=" + Base64.encodeBase64String("{\"key\":\"value\"}".getBytes(UTF_8)))
+        );
     }
 
     @Test
     public void GIVEN_aPopulatedContextWithoutAnyFields_EXPECT_aValidHeaderValue() {
-        final String encoded = codec.encode(new PropagationContext("abc", "123", "myDataset", Collections.emptyMap())).get();
+        final Map<String, String> encoded = codec.encode(new PropagationContext("abc", "123", "myDataset", Collections.emptyMap())).get();
 
-        assertThat(encoded).isEqualTo("1;trace_id=abc,parent_id=123,dataset=myDataset");
+        assertThat(encoded).isEqualTo(
+            Map.of(HttpHeaderV1PropagationCodec.HONEYCOMB_TRACE_HEADER, "1;trace_id=abc,parent_id=123,dataset=myDataset")
+        );
     }
 
     @Test
     public void GIVEN_aPopulatedContextWithAComplexObject_EXPECT_aValidHeaderValue() {
-        final String encoded = codec.encode(new PropagationContext("abc", "123", "myDataset", Collections.singletonMap("key", Collections.singletonMap("nested-key", "value")))).get();
+        final Map<String, String> encoded = codec.encode(new PropagationContext("abc", "123", "myDataset", Collections.singletonMap("key", Collections.singletonMap("nested-key", "value")))).get();
 
-        assertThat(encoded).isEqualTo("1;trace_id=abc,parent_id=123,dataset=myDataset,context=" + Base64.encodeBase64String("{\"key\":{\"nested-key\":\"value\"}}".getBytes(UTF_8)));
+        assertThat(encoded).isEqualTo(
+            Map.of(HttpHeaderV1PropagationCodec.HONEYCOMB_TRACE_HEADER, "1;trace_id=abc,parent_id=123,dataset=myDataset,context=" + Base64.encodeBase64String("{\"key\":{\"nested-key\":\"value\"}}".getBytes(UTF_8)))
+        );
     }
 
     @Test
     public void GIVEN_aPopulatedContextWithAnUnserializableObject_EXPECT_aValidHeaderValueOmittingContext() {
-        final String encoded = codec.encode(new PropagationContext("abc", "123", "myDataset", Collections.singletonMap("key", Collections.singletonMap("nested-key", new Unserializable())))).get();
+        final Map<String, String> encoded = codec.encode(new PropagationContext("abc", "123", "myDataset", Collections.singletonMap("key", Collections.singletonMap("nested-key", new Unserializable())))).get();
 
-        assertThat(encoded).isEqualTo("1;trace_id=abc,parent_id=123,dataset=myDataset");
+        assertThat(encoded).isEqualTo(
+            Map.of(HttpHeaderV1PropagationCodec.HONEYCOMB_TRACE_HEADER, "1;trace_id=abc,parent_id=123,dataset=myDataset")
+        );
     }
 
     public static class Unserializable {

--- a/beeline-core/src/test/java/io/honeycomb/beeline/tracing/propagation/HttpHeaderV1PropagationCodecTest.java
+++ b/beeline-core/src/test/java/io/honeycomb/beeline/tracing/propagation/HttpHeaderV1PropagationCodecTest.java
@@ -38,7 +38,7 @@ public class HttpHeaderV1PropagationCodecTest {
         final String jsonAsBase64 = Base64.encodeBase64String(jsonString.getBytes(UTF_8));
         final String traceHeader = "1;trace_id=123,parent_id=abc,dataset=hellodataset,context=" + jsonAsBase64;
 
-        final PropagationContext decode = codec.decode(Map.of(HttpHeaderV1PropagationCodec.HONEYCOMB_TRACE_HEADER, traceHeader));
+        final PropagationContext decode = codec.decode(Collections.singletonMap(HttpHeaderV1PropagationCodec.HONEYCOMB_TRACE_HEADER, traceHeader));
 
         assertThat(decode.getSpanId()).isEqualTo("abc");
         assertThat(decode.getTraceId()).isEqualTo("123");
@@ -52,7 +52,7 @@ public class HttpHeaderV1PropagationCodecTest {
         final String jsonAsBase64 = Base64.encodeBase64String(jsonString.getBytes(UTF_8));
         final String traceHeader = "1;context=" + jsonAsBase64 + ",dataset=hellodataset,parent_id=abc,trace_id=123";
 
-        final PropagationContext decode = codec.decode(Map.of(HttpHeaderV1PropagationCodec.HONEYCOMB_TRACE_HEADER, traceHeader));
+        final PropagationContext decode = codec.decode(Collections.singletonMap(HttpHeaderV1PropagationCodec.HONEYCOMB_TRACE_HEADER, traceHeader));
 
         assertThat(decode.getSpanId()).isEqualTo("abc");
         assertThat(decode.getTraceId()).isEqualTo("123");
@@ -66,7 +66,7 @@ public class HttpHeaderV1PropagationCodecTest {
         final String jsonAsBase64 = Base64.encodeBase64String(jsonString.getBytes(UTF_8));
         final String traceHeader = "1;trace_id=beef-patty,parent_id=turkey_roast,context=" + jsonAsBase64;
 
-        final PropagationContext decode = codec.decode(Map.of(HttpHeaderV1PropagationCodec.HONEYCOMB_TRACE_HEADER, traceHeader));
+        final PropagationContext decode = codec.decode(Collections.singletonMap(HttpHeaderV1PropagationCodec.HONEYCOMB_TRACE_HEADER, traceHeader));
 
         assertThat(decode.getSpanId()).isEqualTo("turkey_roast");
         assertThat(decode.getTraceId()).isEqualTo("beef-patty");
@@ -80,7 +80,7 @@ public class HttpHeaderV1PropagationCodecTest {
     public void GIVEN_aValidTraceThatHasAContextOfNull_EXPECT_toDecodeCorrectly() {
         final String traceHeader = "1;trace_id=123,parent_id=abc,context=" + null;
 
-        final PropagationContext decode = codec.decode(Map.of(HttpHeaderV1PropagationCodec.HONEYCOMB_TRACE_HEADER, traceHeader));
+        final PropagationContext decode = codec.decode(Collections.singletonMap(HttpHeaderV1PropagationCodec.HONEYCOMB_TRACE_HEADER, traceHeader));
 
         assertThat(decode.getSpanId()).isEqualTo("abc");
         assertThat(decode.getTraceId()).isEqualTo("123");
@@ -91,7 +91,7 @@ public class HttpHeaderV1PropagationCodecTest {
     public void GIVEN_aValidTraceThatHasAMissingDataset_EXPECT_datasetToBeNull() {
         final String traceHeader = "1;trace_id=123,parent_id=abc";
 
-        final PropagationContext decode = codec.decode(Map.of(HttpHeaderV1PropagationCodec.HONEYCOMB_TRACE_HEADER, traceHeader));
+        final PropagationContext decode = codec.decode(Collections.singletonMap(HttpHeaderV1PropagationCodec.HONEYCOMB_TRACE_HEADER, traceHeader));
 
         assertThat(decode.getDataset()).isEqualTo(null);
     }
@@ -100,7 +100,7 @@ public class HttpHeaderV1PropagationCodecTest {
     public void GIVEN_aValidTraceThatHasAnEncodedDataset_EXPECT_datasetToBeDecoded() {
         final String traceHeader = "1;trace_id=123,parent_id=abc,dataset=%2Fhello+world";
 
-        final PropagationContext decode = codec.decode(Map.of(HttpHeaderV1PropagationCodec.HONEYCOMB_TRACE_HEADER, traceHeader));
+        final PropagationContext decode = codec.decode(Collections.singletonMap(HttpHeaderV1PropagationCodec.HONEYCOMB_TRACE_HEADER, traceHeader));
 
         assertThat(decode.getDataset()).isEqualTo("/hello world");
     }
@@ -109,7 +109,7 @@ public class HttpHeaderV1PropagationCodecTest {
     public void GIVEN_aTraceHeaderMissingParentID_EXPECT_emptyContext() {
         final String traceHeader = "1;trace_id=123";
 
-        final PropagationContext decode = codec.decode(Map.of(HttpHeaderV1PropagationCodec.HONEYCOMB_TRACE_HEADER, traceHeader));
+        final PropagationContext decode = codec.decode(Collections.singletonMap(HttpHeaderV1PropagationCodec.HONEYCOMB_TRACE_HEADER, traceHeader));
 
         assertThat(decode).isEqualTo(PropagationContext.emptyContext());
     }
@@ -118,7 +118,7 @@ public class HttpHeaderV1PropagationCodecTest {
     public void GIVEN_aTraceHeaderMissingTraceID_EXPECT_emptyContext() {
         final String traceHeader = "1;parent_id=123";
 
-        final PropagationContext decode = codec.decode(Map.of(HttpHeaderV1PropagationCodec.HONEYCOMB_TRACE_HEADER, traceHeader));
+        final PropagationContext decode = codec.decode(Collections.singletonMap(HttpHeaderV1PropagationCodec.HONEYCOMB_TRACE_HEADER, traceHeader));
 
         assertThat(decode).isEqualTo(PropagationContext.emptyContext());
     }
@@ -127,7 +127,7 @@ public class HttpHeaderV1PropagationCodecTest {
     public void GIVEN_aTraceHeaderThePayloadPart_EXPECT_emptyContext() {
         final String traceHeader = "1;";
 
-        final PropagationContext decode = codec.decode(Map.of(HttpHeaderV1PropagationCodec.HONEYCOMB_TRACE_HEADER, traceHeader));
+        final PropagationContext decode = codec.decode(Collections.singletonMap(HttpHeaderV1PropagationCodec.HONEYCOMB_TRACE_HEADER, traceHeader));
 
         assertThat(decode).isEqualTo(PropagationContext.emptyContext());
     }
@@ -136,7 +136,7 @@ public class HttpHeaderV1PropagationCodecTest {
     public void GIVEN_aValidTraceThatOmitsTraceFields_EXPECT_toDecodeCorrectly() {
         final String traceHeader = "1;trace_id=123,parent_id=abc";
 
-        final PropagationContext decode = codec.decode(Map.of(HttpHeaderV1PropagationCodec.HONEYCOMB_TRACE_HEADER, traceHeader));
+        final PropagationContext decode = codec.decode(Collections.singletonMap(HttpHeaderV1PropagationCodec.HONEYCOMB_TRACE_HEADER, traceHeader));
 
         assertThat(decode.getSpanId()).isEqualTo("abc");
         assertThat(decode.getTraceId()).isEqualTo("123");
@@ -152,7 +152,7 @@ public class HttpHeaderV1PropagationCodecTest {
         final JsonDeserializer deserializer = mock(JsonDeserializer.class);
         codec = new HttpHeaderV1PropagationCodec(serializer, deserializer);
 
-        codec.decode(Map.of(HttpHeaderV1PropagationCodec.HONEYCOMB_TRACE_HEADER, traceHeader));
+        codec.decode(Collections.singletonMap(HttpHeaderV1PropagationCodec.HONEYCOMB_TRACE_HEADER, traceHeader));
 
         verify(deserializer).deserialize(jsonString.getBytes("utf-8"));
         verifyZeroInteractions(serializer);
@@ -164,7 +164,7 @@ public class HttpHeaderV1PropagationCodecTest {
         final String jsonAsBase64 = Base64.encodeBase64String(jsonString.getBytes(UTF_8));
         final String traceHeader = "1;christmas_food=mince_pie,trace_id=123,parent_id=abc,context=" + jsonAsBase64;
 
-        final PropagationContext decode = codec.decode(Map.of(HttpHeaderV1PropagationCodec.HONEYCOMB_TRACE_HEADER, traceHeader));
+        final PropagationContext decode = codec.decode(Collections.singletonMap(HttpHeaderV1PropagationCodec.HONEYCOMB_TRACE_HEADER, traceHeader));
 
         assertThat(decode.getSpanId()).isEqualTo("abc");
         assertThat(decode.getTraceId()).isEqualTo("123");
@@ -173,7 +173,7 @@ public class HttpHeaderV1PropagationCodecTest {
 
     @Test
     public void GIVEN_amEmptyParameter_EXPECT_anEmptyContext() {
-        final PropagationContext decode = codec.decode(Map.of(HttpHeaderV1PropagationCodec.HONEYCOMB_TRACE_HEADER, ""));
+        final PropagationContext decode = codec.decode(Collections.singletonMap(HttpHeaderV1PropagationCodec.HONEYCOMB_TRACE_HEADER, ""));
 
         assertThat(decode).isEqualTo(PropagationContext.emptyContext());
     }
@@ -191,7 +191,7 @@ public class HttpHeaderV1PropagationCodecTest {
         final String jsonAsBase64 = Base64.encodeBase64String(jsonString.getBytes(UTF_8));
         final String traceHeader = "1;parent_id=abc,context=" + jsonAsBase64;
 
-        final PropagationContext decode = codec.decode(Map.of(HttpHeaderV1PropagationCodec.HONEYCOMB_TRACE_HEADER, traceHeader));
+        final PropagationContext decode = codec.decode(Collections.singletonMap(HttpHeaderV1PropagationCodec.HONEYCOMB_TRACE_HEADER, traceHeader));
 
         assertThat(decode).isEqualTo(PropagationContext.emptyContext());
     }
@@ -202,7 +202,7 @@ public class HttpHeaderV1PropagationCodecTest {
         final String jsonAsBase64 = Base64.encodeBase64String(jsonString.getBytes(UTF_8));
         final String traceHeader = "1;trace_id=abc,context=" + jsonAsBase64;
 
-        final PropagationContext decode = codec.decode(Map.of(HttpHeaderV1PropagationCodec.HONEYCOMB_TRACE_HEADER, traceHeader));
+        final PropagationContext decode = codec.decode(Collections.singletonMap(HttpHeaderV1PropagationCodec.HONEYCOMB_TRACE_HEADER, traceHeader));
 
         assertThat(decode).isEqualTo(PropagationContext.emptyContext());
     }
@@ -214,7 +214,7 @@ public class HttpHeaderV1PropagationCodecTest {
         final String versionString = "2";
         final String traceHeader = versionString + ";parent_id=123,trace_id=abc,context=" + jsonAsBase64;
 
-        final PropagationContext decode = codec.decode(Map.of(HttpHeaderV1PropagationCodec.HONEYCOMB_TRACE_HEADER, traceHeader));
+        final PropagationContext decode = codec.decode(Collections.singletonMap(HttpHeaderV1PropagationCodec.HONEYCOMB_TRACE_HEADER, traceHeader));
 
         assertThat(decode).isEqualTo(PropagationContext.emptyContext());
     }
@@ -226,7 +226,7 @@ public class HttpHeaderV1PropagationCodecTest {
         // wrong separator between the version and payload:
         final String traceHeader = "1,parent_id=123,trace_id=abc,context=" + jsonAsBase64;
 
-        final PropagationContext decode = codec.decode(Map.of(HttpHeaderV1PropagationCodec.HONEYCOMB_TRACE_HEADER, traceHeader));
+        final PropagationContext decode = codec.decode(Collections.singletonMap(HttpHeaderV1PropagationCodec.HONEYCOMB_TRACE_HEADER, traceHeader));
 
         assertThat(decode).isEqualTo(PropagationContext.emptyContext());
     }
@@ -238,7 +238,7 @@ public class HttpHeaderV1PropagationCodecTest {
         // wrong separator between the version and payload:
         final String traceHeader = "1;parent_id=123,trace_id=abc,context=" + jsonAsBase64;
 
-        final PropagationContext decode = codec.decode(Map.of(HttpHeaderV1PropagationCodec.HONEYCOMB_TRACE_HEADER, traceHeader));
+        final PropagationContext decode = codec.decode(Collections.singletonMap(HttpHeaderV1PropagationCodec.HONEYCOMB_TRACE_HEADER, traceHeader));
 
         assertThat(decode.getSpanId()).isEqualTo("123");
         assertThat(decode.getTraceId()).isEqualTo("abc");
@@ -252,7 +252,7 @@ public class HttpHeaderV1PropagationCodecTest {
         // wrong separator between the version and payload:
         final String traceHeader = "1;parent_id=123,trace_id=abc,context=" + "$" + jsonAsBase64;
 
-        final PropagationContext decode = codec.decode(Map.of(HttpHeaderV1PropagationCodec.HONEYCOMB_TRACE_HEADER, traceHeader));
+        final PropagationContext decode = codec.decode(Collections.singletonMap(HttpHeaderV1PropagationCodec.HONEYCOMB_TRACE_HEADER, traceHeader));
 
         assertThat(decode.getSpanId()).isEqualTo("123");
         assertThat(decode.getTraceId()).isEqualTo("abc");
@@ -278,7 +278,7 @@ public class HttpHeaderV1PropagationCodecTest {
         final Map<String, String> encoded = codec.encode(new PropagationContext("abc", "123", "myDataset", Collections.singletonMap("key", "value"))).get();
 
         assertThat(encoded).isEqualTo(
-            Map.of(HttpHeaderV1PropagationCodec.HONEYCOMB_TRACE_HEADER, "1;trace_id=abc,parent_id=123,dataset=myDataset,context=" + Base64.encodeBase64String("{\"key\":\"value\"}".getBytes(UTF_8)))
+            Collections.singletonMap(HttpHeaderV1PropagationCodec.HONEYCOMB_TRACE_HEADER, "1;trace_id=abc,parent_id=123,dataset=myDataset,context=" + Base64.encodeBase64String("{\"key\":\"value\"}".getBytes(UTF_8)))
         );
     }
 
@@ -287,7 +287,7 @@ public class HttpHeaderV1PropagationCodecTest {
         final Map<String, String> encoded = codec.encode(new PropagationContext("abc", "123", "/hello world", Collections.singletonMap("key", "value"))).get();
 
         assertThat(encoded).isEqualTo(
-            Map.of(HttpHeaderV1PropagationCodec.HONEYCOMB_TRACE_HEADER, "1;trace_id=abc,parent_id=123,dataset=%2Fhello+world,context=" + Base64.encodeBase64String("{\"key\":\"value\"}".getBytes(UTF_8)))
+            Collections.singletonMap(HttpHeaderV1PropagationCodec.HONEYCOMB_TRACE_HEADER, "1;trace_id=abc,parent_id=123,dataset=%2Fhello+world,context=" + Base64.encodeBase64String("{\"key\":\"value\"}".getBytes(UTF_8)))
         );
     }
 
@@ -297,7 +297,7 @@ public class HttpHeaderV1PropagationCodecTest {
         final Map<String, String> encoded = codec.encode(new PropagationContext("abc", "123", null, Collections.singletonMap("key", "value"))).get();
 
         assertThat(encoded).isEqualTo(
-            Map.of(HttpHeaderV1PropagationCodec.HONEYCOMB_TRACE_HEADER, "1;trace_id=abc,parent_id=123,context=" + Base64.encodeBase64String("{\"key\":\"value\"}".getBytes(UTF_8)))
+            Collections.singletonMap(HttpHeaderV1PropagationCodec.HONEYCOMB_TRACE_HEADER, "1;trace_id=abc,parent_id=123,context=" + Base64.encodeBase64String("{\"key\":\"value\"}".getBytes(UTF_8)))
         );
     }
 
@@ -306,7 +306,7 @@ public class HttpHeaderV1PropagationCodecTest {
         final Map<String, String> encoded = codec.encode(new PropagationContext("abc", "123", "myDataset", Collections.emptyMap())).get();
 
         assertThat(encoded).isEqualTo(
-            Map.of(HttpHeaderV1PropagationCodec.HONEYCOMB_TRACE_HEADER, "1;trace_id=abc,parent_id=123,dataset=myDataset")
+            Collections.singletonMap(HttpHeaderV1PropagationCodec.HONEYCOMB_TRACE_HEADER, "1;trace_id=abc,parent_id=123,dataset=myDataset")
         );
     }
 
@@ -315,7 +315,7 @@ public class HttpHeaderV1PropagationCodecTest {
         final Map<String, String> encoded = codec.encode(new PropagationContext("abc", "123", "myDataset", Collections.singletonMap("key", Collections.singletonMap("nested-key", "value")))).get();
 
         assertThat(encoded).isEqualTo(
-            Map.of(HttpHeaderV1PropagationCodec.HONEYCOMB_TRACE_HEADER, "1;trace_id=abc,parent_id=123,dataset=myDataset,context=" + Base64.encodeBase64String("{\"key\":{\"nested-key\":\"value\"}}".getBytes(UTF_8)))
+            Collections.singletonMap(HttpHeaderV1PropagationCodec.HONEYCOMB_TRACE_HEADER, "1;trace_id=abc,parent_id=123,dataset=myDataset,context=" + Base64.encodeBase64String("{\"key\":{\"nested-key\":\"value\"}}".getBytes(UTF_8)))
         );
     }
 
@@ -324,7 +324,7 @@ public class HttpHeaderV1PropagationCodecTest {
         final Map<String, String> encoded = codec.encode(new PropagationContext("abc", "123", "myDataset", Collections.singletonMap("key", Collections.singletonMap("nested-key", new Unserializable())))).get();
 
         assertThat(encoded).isEqualTo(
-            Map.of(HttpHeaderV1PropagationCodec.HONEYCOMB_TRACE_HEADER, "1;trace_id=abc,parent_id=123,dataset=myDataset")
+            Collections.singletonMap(HttpHeaderV1PropagationCodec.HONEYCOMB_TRACE_HEADER, "1;trace_id=abc,parent_id=123,dataset=myDataset")
         );
     }
 

--- a/beeline-core/src/test/java/io/honeycomb/beeline/tracing/propagation/HttpServerPropagatorTest.java
+++ b/beeline-core/src/test/java/io/honeycomb/beeline/tracing/propagation/HttpServerPropagatorTest.java
@@ -1,5 +1,5 @@
 package io.honeycomb.beeline.tracing.propagation;
- 
+
 import io.honeycomb.beeline.tracing.Beeline;
 import io.honeycomb.beeline.tracing.Span;
 import io.honeycomb.libhoney.shaded.org.apache.http.HttpHeaders;
@@ -9,6 +9,7 @@ import org.junit.runner.RunWith;
 import org.mockito.Mock;
 import org.mockito.junit.MockitoJUnitRunner;
 
+import java.util.Map;
 import java.util.Optional;
 import java.util.function.Function;
 
@@ -27,7 +28,7 @@ public class HttpServerPropagatorTest {
     @Mock
     private HttpServerRequestSpanCustomizer mockSpanCustomizer;
     @Mock
-    private PropagationCodec<String> mockPropagationCodec;
+    private PropagationCodec<Map<String, String>> mockPropagationCodec;
     @Mock
     private Beeline mockBeeline;
     @Mock
@@ -49,9 +50,10 @@ public class HttpServerPropagatorTest {
     @Test
     public void whenStartPropagation_traceIsStarted_andHttpFieldsAreApplied() {
         final String expectedTraceHeader = "expectedTraceHeader";
-        when(mockHttpRequest.getFirstHeader(HttpHeaderV1PropagationCodec.HONEYCOMB_TRACE_HEADER)).thenReturn(Optional.of(expectedTraceHeader));
-        when(mockPropagationCodec.decode(expectedTraceHeader)).thenReturn(mockPropagationContext);
-        when(mockBeeline.startTrace(EXPECTED_SPAN_NAME, mockPropagationContext, EXPECTED_SERVICE_NAME)).thenReturn(mockSpan);
+        // TODO: Fix thes
+        // when(mockHttpRequest.getFirstHeader(HttpHeaderV1PropagationCodec.HONEYCOMB_TRACE_HEADER)).thenReturn(Optional.of(expectedTraceHeader));
+        // when(mockPropagationCodec.decode(Map.of(HttpHeaderV1PropagationCodec.HONEYCOMB_TRACE_HEADER, expectedTraceHeader))).thenReturn(mockPropagationContext);
+        // when(mockBeeline.startTrace(EXPECTED_SPAN_NAME, mockPropagationContext, EXPECTED_SERVICE_NAME)).thenReturn(mockSpan);
 
         final Span span = httpServerPropagator.startPropagation(mockHttpRequest);
         verify(mockSpanCustomizer).customize(span, mockHttpRequest);
@@ -59,8 +61,9 @@ public class HttpServerPropagatorTest {
 
     @Test
     public void whenStartPropagation_andNoTraceHeaderIsPresent_traceIsStarted_andHttpFieldsAreApplied() {
-        when(mockPropagationCodec.decode(null)).thenReturn(mockPropagationContext);
-        when(mockBeeline.startTrace(EXPECTED_SPAN_NAME, mockPropagationContext, EXPECTED_SERVICE_NAME)).thenReturn(mockSpan);
+        // TODO: Fix these
+        // when(mockPropagationCodec.decode(null)).thenReturn(mockPropagationContext);
+        // when(mockBeeline.startTrace(EXPECTED_SPAN_NAME, mockPropagationContext, EXPECTED_SERVICE_NAME)).thenReturn(mockSpan);
 
         final Span span = httpServerPropagator.startPropagation(mockHttpRequest);
         verify(mockSpanCustomizer).customize(span, mockHttpRequest);

--- a/beeline-core/src/test/java/io/honeycomb/beeline/tracing/propagation/HttpServerPropagatorTest.java
+++ b/beeline-core/src/test/java/io/honeycomb/beeline/tracing/propagation/HttpServerPropagatorTest.java
@@ -9,6 +9,7 @@ import org.junit.runner.RunWith;
 import org.mockito.Mock;
 import org.mockito.junit.MockitoJUnitRunner;
 
+import java.util.Collections;
 import java.util.Map;
 import java.util.Optional;
 import java.util.function.Function;
@@ -50,8 +51,8 @@ public class HttpServerPropagatorTest {
     @Test
     public void whenStartPropagation_traceIsStarted_andHttpFieldsAreApplied() {
         final String expectedTraceHeader = "expectedTraceHeader";
-        when(mockHttpRequest.getHeaders()).thenReturn(Map.of(HttpHeaderV1PropagationCodec.HONEYCOMB_TRACE_HEADER, expectedTraceHeader));
-        when(mockPropagationCodec.decode(Map.of(HttpHeaderV1PropagationCodec.HONEYCOMB_TRACE_HEADER, expectedTraceHeader))).thenReturn(mockPropagationContext);
+        when(mockHttpRequest.getHeaders()).thenReturn(Collections.singletonMap(HttpHeaderV1PropagationCodec.HONEYCOMB_TRACE_HEADER, expectedTraceHeader));
+        when(mockPropagationCodec.decode(Collections.singletonMap(HttpHeaderV1PropagationCodec.HONEYCOMB_TRACE_HEADER, expectedTraceHeader))).thenReturn(mockPropagationContext);
         when(mockBeeline.startTrace(EXPECTED_SPAN_NAME, mockPropagationContext, EXPECTED_SERVICE_NAME)).thenReturn(mockSpan);
 
         final Span span = httpServerPropagator.startPropagation(mockHttpRequest);
@@ -60,7 +61,7 @@ public class HttpServerPropagatorTest {
 
     @Test
     public void whenStartPropagation_andNoTraceHeaderIsPresent_traceIsStarted_andHttpFieldsAreApplied() {
-        when(mockPropagationCodec.decode(Map.of())).thenReturn(mockPropagationContext);
+        when(mockPropagationCodec.decode(Collections.emptyMap())).thenReturn(mockPropagationContext);
         when(mockBeeline.startTrace(EXPECTED_SPAN_NAME, mockPropagationContext, EXPECTED_SERVICE_NAME)).thenReturn(mockSpan);
 
         final Span span = httpServerPropagator.startPropagation(mockHttpRequest);

--- a/beeline-core/src/test/java/io/honeycomb/beeline/tracing/propagation/HttpServerPropagatorTest.java
+++ b/beeline-core/src/test/java/io/honeycomb/beeline/tracing/propagation/HttpServerPropagatorTest.java
@@ -50,10 +50,9 @@ public class HttpServerPropagatorTest {
     @Test
     public void whenStartPropagation_traceIsStarted_andHttpFieldsAreApplied() {
         final String expectedTraceHeader = "expectedTraceHeader";
-        // TODO: Fix thes
-        // when(mockHttpRequest.getFirstHeader(HttpHeaderV1PropagationCodec.HONEYCOMB_TRACE_HEADER)).thenReturn(Optional.of(expectedTraceHeader));
-        // when(mockPropagationCodec.decode(Map.of(HttpHeaderV1PropagationCodec.HONEYCOMB_TRACE_HEADER, expectedTraceHeader))).thenReturn(mockPropagationContext);
-        // when(mockBeeline.startTrace(EXPECTED_SPAN_NAME, mockPropagationContext, EXPECTED_SERVICE_NAME)).thenReturn(mockSpan);
+        when(mockHttpRequest.getHeaders()).thenReturn(Map.of(HttpHeaderV1PropagationCodec.HONEYCOMB_TRACE_HEADER, expectedTraceHeader));
+        when(mockPropagationCodec.decode(Map.of(HttpHeaderV1PropagationCodec.HONEYCOMB_TRACE_HEADER, expectedTraceHeader))).thenReturn(mockPropagationContext);
+        when(mockBeeline.startTrace(EXPECTED_SPAN_NAME, mockPropagationContext, EXPECTED_SERVICE_NAME)).thenReturn(mockSpan);
 
         final Span span = httpServerPropagator.startPropagation(mockHttpRequest);
         verify(mockSpanCustomizer).customize(span, mockHttpRequest);
@@ -61,9 +60,8 @@ public class HttpServerPropagatorTest {
 
     @Test
     public void whenStartPropagation_andNoTraceHeaderIsPresent_traceIsStarted_andHttpFieldsAreApplied() {
-        // TODO: Fix these
-        // when(mockPropagationCodec.decode(null)).thenReturn(mockPropagationContext);
-        // when(mockBeeline.startTrace(EXPECTED_SPAN_NAME, mockPropagationContext, EXPECTED_SERVICE_NAME)).thenReturn(mockSpan);
+        when(mockPropagationCodec.decode(Map.of())).thenReturn(mockPropagationContext);
+        when(mockBeeline.startTrace(EXPECTED_SPAN_NAME, mockPropagationContext, EXPECTED_SERVICE_NAME)).thenReturn(mockSpan);
 
         final Span span = httpServerPropagator.startPropagation(mockHttpRequest);
         verify(mockSpanCustomizer).customize(span, mockHttpRequest);

--- a/beeline-core/src/test/java/io/honeycomb/beeline/tracing/propagation/W3CPropagationCodecTest.java
+++ b/beeline-core/src/test/java/io/honeycomb/beeline/tracing/propagation/W3CPropagationCodecTest.java
@@ -5,6 +5,7 @@ import org.junit.Test;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
+import java.util.Map;
 import java.util.Optional;
 
 public class W3CPropagationCodecTest {
@@ -27,7 +28,7 @@ public class W3CPropagationCodecTest {
 
     @Test
     public void GIVEN_amEmptyParameter_EXPECT_anEmptyContext() {
-        final PropagationContext context = codec.decode("");
+        final PropagationContext context = codec.decode(Map.of(W3CPropagationCodec.W3C_TRACEPARENT_HEADER, ""));
 
         assertThat(context).isEqualTo(PropagationContext.emptyContext());
     }
@@ -35,7 +36,7 @@ public class W3CPropagationCodecTest {
     @Test
     public void GIVEN_aValidTraceValue_EXPECT_toDecodeCorrectly() {
         final String traceHeader = "00-4cbc8d50f02449e887e8bc2aa8020d26-ace1ecab581fc069-00";
-        final PropagationContext context = codec.decode(traceHeader);
+        final PropagationContext context = codec.decode(Map.of(W3CPropagationCodec.W3C_TRACEPARENT_HEADER, traceHeader));
 
         assertThat(context.getTraceId()).isEqualTo("4cbc8d50f02449e887e8bc2aa8020d26");
         assertThat(context.getSpanId()).isEqualTo("ace1ecab581fc069");
@@ -45,7 +46,7 @@ public class W3CPropagationCodecTest {
     @Test
     public void GIVEN_aValidTraceValueWithSampledTraceFlag_EXPECT_toDecodeCorrectly() {
         final String traceHeader = "00-4cbc8d50f02449e887e8bc2aa8020d26-ace1ecab581fc069-01";
-        final PropagationContext context = codec.decode(traceHeader);
+        final PropagationContext context = codec.decode(Map.of(W3CPropagationCodec.W3C_TRACEPARENT_HEADER, traceHeader));
 
         assertThat(context.getTraceId()).isEqualTo("4cbc8d50f02449e887e8bc2aa8020d26");
         assertThat(context.getSpanId()).isEqualTo("ace1ecab581fc069");
@@ -56,7 +57,7 @@ public class W3CPropagationCodecTest {
     public void GIVEN_aTraceHeaderTooFewSegments_EXPECT_anEmptyContext() {
         final String traceHeader = "1-2-3";
 
-        final PropagationContext context = codec.decode(traceHeader);
+        final PropagationContext context = codec.decode(Map.of(W3CPropagationCodec.W3C_TRACEPARENT_HEADER, traceHeader));
 
         assertThat(context).isEqualTo(PropagationContext.emptyContext());
     }
@@ -65,7 +66,7 @@ public class W3CPropagationCodecTest {
     public void GIVEN_aTraceHeaderTooManySegments_EXPECT_anEmptyContext() {
         final String traceHeader = "1-2-3-4-5";
 
-        final PropagationContext context = codec.decode(traceHeader);
+        final PropagationContext context = codec.decode(Map.of(W3CPropagationCodec.W3C_TRACEPARENT_HEADER, traceHeader));
 
         assertThat(context).isEqualTo(PropagationContext.emptyContext());
     }
@@ -75,7 +76,7 @@ public class W3CPropagationCodecTest {
     public void GIVEN_aTraceHeaderWithInvalidVersion_EXPECT_anEmptyContext() {
         final String traceHeader = "invalid-4cbc8d50f02449e887e8bc2aa8020d26-ace1ecab581fc069-00";
 
-        final PropagationContext context = codec.decode(traceHeader);
+        final PropagationContext context = codec.decode(Map.of(W3CPropagationCodec.W3C_TRACEPARENT_HEADER, traceHeader));
 
         assertThat(context).isEqualTo(PropagationContext.emptyContext());
     }
@@ -84,7 +85,7 @@ public class W3CPropagationCodecTest {
     public void GIVEN_aTraceHeaderWithInvalidTraceId_EXPECT_anEmptyContext() {
         final String traceHeader = "00-invalid-ace1ecab581fc069-00";
 
-        final PropagationContext context = codec.decode(traceHeader);
+        final PropagationContext context = codec.decode(Map.of(W3CPropagationCodec.W3C_TRACEPARENT_HEADER, traceHeader));
 
         assertThat(context).isEqualTo(PropagationContext.emptyContext());
     }
@@ -93,7 +94,7 @@ public class W3CPropagationCodecTest {
     public void GIVEN_aTraceHeaderWithInvalidSpanId_EXPECT_anEmptyContext() {
         final String traceHeader = "00-4cbc8d50f02449e887e8bc2aa8020d26-invalid-00";
 
-        final PropagationContext context = codec.decode(traceHeader);
+        final PropagationContext context = codec.decode(Map.of(W3CPropagationCodec.W3C_TRACEPARENT_HEADER, traceHeader));
 
         assertThat(context).isEqualTo(PropagationContext.emptyContext());
     }
@@ -102,7 +103,7 @@ public class W3CPropagationCodecTest {
     public void GIVEN_aTraceHeaderWithInvalidTraceFlags_EXPECT_anEmptyContext() {
         final String traceHeader = "00-4cbc8d50f02449e887e8bc2aa8020d26-ace1ecab581fc069-invalid";
 
-        final PropagationContext context = codec.decode(traceHeader);
+        final PropagationContext context = codec.decode(Map.of(W3CPropagationCodec.W3C_TRACEPARENT_HEADER, traceHeader));
 
         assertThat(context).isEqualTo(PropagationContext.emptyContext());
     }
@@ -111,7 +112,7 @@ public class W3CPropagationCodecTest {
 
     @Test
     public void GIVEN_anEmptyContext_EXPECT_empty() {
-        final Optional<String> encoded = codec.encode(PropagationContext.emptyContext());
+        final Optional<Map<String, String>> encoded = codec.encode(PropagationContext.emptyContext());
 
         assertThat(encoded).isEmpty();
     }
@@ -120,8 +121,10 @@ public class W3CPropagationCodecTest {
     public void GIVEN_aPopulatedContext_EXPECT_aValidHeaderValue() {
         String traceId = "4cbc8d50f02449e887e8bc2aa8020d26";
         String spanId = "ace1ecab581fc069";
-        final String encoded = codec.encode(new PropagationContext(traceId, spanId, null, null)).get();
+        final Map<String, String> encoded = codec.encode(new PropagationContext(traceId, spanId, null, null)).get();
 
-        assertThat(encoded).isEqualTo(String.join("-", "00", traceId, spanId, "00"));
+        assertThat(encoded).isEqualTo(
+            Map.of(W3CPropagationCodec.W3C_TRACEPARENT_HEADER, String.join("-", "00", traceId, spanId, "00"))
+        );
     }
 }

--- a/beeline-core/src/test/java/io/honeycomb/beeline/tracing/propagation/W3CPropagationCodecTest.java
+++ b/beeline-core/src/test/java/io/honeycomb/beeline/tracing/propagation/W3CPropagationCodecTest.java
@@ -5,6 +5,7 @@ import org.junit.Test;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
+import java.util.Collections;
 import java.util.Map;
 import java.util.Optional;
 
@@ -28,7 +29,7 @@ public class W3CPropagationCodecTest {
 
     @Test
     public void GIVEN_amEmptyParameter_EXPECT_anEmptyContext() {
-        final PropagationContext context = codec.decode(Map.of(W3CPropagationCodec.W3C_TRACEPARENT_HEADER, ""));
+        final PropagationContext context = codec.decode(Collections.singletonMap(W3CPropagationCodec.W3C_TRACEPARENT_HEADER, ""));
 
         assertThat(context).isEqualTo(PropagationContext.emptyContext());
     }
@@ -36,7 +37,7 @@ public class W3CPropagationCodecTest {
     @Test
     public void GIVEN_aValidTraceValue_EXPECT_toDecodeCorrectly() {
         final String traceHeader = "00-4cbc8d50f02449e887e8bc2aa8020d26-ace1ecab581fc069-00";
-        final PropagationContext context = codec.decode(Map.of(W3CPropagationCodec.W3C_TRACEPARENT_HEADER, traceHeader));
+        final PropagationContext context = codec.decode(Collections.singletonMap(W3CPropagationCodec.W3C_TRACEPARENT_HEADER, traceHeader));
 
         assertThat(context.getTraceId()).isEqualTo("4cbc8d50f02449e887e8bc2aa8020d26");
         assertThat(context.getSpanId()).isEqualTo("ace1ecab581fc069");
@@ -46,7 +47,7 @@ public class W3CPropagationCodecTest {
     @Test
     public void GIVEN_aValidTraceValueWithSampledTraceFlag_EXPECT_toDecodeCorrectly() {
         final String traceHeader = "00-4cbc8d50f02449e887e8bc2aa8020d26-ace1ecab581fc069-01";
-        final PropagationContext context = codec.decode(Map.of(W3CPropagationCodec.W3C_TRACEPARENT_HEADER, traceHeader));
+        final PropagationContext context = codec.decode(Collections.singletonMap(W3CPropagationCodec.W3C_TRACEPARENT_HEADER, traceHeader));
 
         assertThat(context.getTraceId()).isEqualTo("4cbc8d50f02449e887e8bc2aa8020d26");
         assertThat(context.getSpanId()).isEqualTo("ace1ecab581fc069");
@@ -57,7 +58,7 @@ public class W3CPropagationCodecTest {
     public void GIVEN_aTraceHeaderTooFewSegments_EXPECT_anEmptyContext() {
         final String traceHeader = "1-2-3";
 
-        final PropagationContext context = codec.decode(Map.of(W3CPropagationCodec.W3C_TRACEPARENT_HEADER, traceHeader));
+        final PropagationContext context = codec.decode(Collections.singletonMap(W3CPropagationCodec.W3C_TRACEPARENT_HEADER, traceHeader));
 
         assertThat(context).isEqualTo(PropagationContext.emptyContext());
     }
@@ -66,7 +67,7 @@ public class W3CPropagationCodecTest {
     public void GIVEN_aTraceHeaderTooManySegments_EXPECT_anEmptyContext() {
         final String traceHeader = "1-2-3-4-5";
 
-        final PropagationContext context = codec.decode(Map.of(W3CPropagationCodec.W3C_TRACEPARENT_HEADER, traceHeader));
+        final PropagationContext context = codec.decode(Collections.singletonMap(W3CPropagationCodec.W3C_TRACEPARENT_HEADER, traceHeader));
 
         assertThat(context).isEqualTo(PropagationContext.emptyContext());
     }
@@ -76,7 +77,7 @@ public class W3CPropagationCodecTest {
     public void GIVEN_aTraceHeaderWithInvalidVersion_EXPECT_anEmptyContext() {
         final String traceHeader = "invalid-4cbc8d50f02449e887e8bc2aa8020d26-ace1ecab581fc069-00";
 
-        final PropagationContext context = codec.decode(Map.of(W3CPropagationCodec.W3C_TRACEPARENT_HEADER, traceHeader));
+        final PropagationContext context = codec.decode(Collections.singletonMap(W3CPropagationCodec.W3C_TRACEPARENT_HEADER, traceHeader));
 
         assertThat(context).isEqualTo(PropagationContext.emptyContext());
     }
@@ -85,7 +86,7 @@ public class W3CPropagationCodecTest {
     public void GIVEN_aTraceHeaderWithInvalidTraceId_EXPECT_anEmptyContext() {
         final String traceHeader = "00-invalid-ace1ecab581fc069-00";
 
-        final PropagationContext context = codec.decode(Map.of(W3CPropagationCodec.W3C_TRACEPARENT_HEADER, traceHeader));
+        final PropagationContext context = codec.decode(Collections.singletonMap(W3CPropagationCodec.W3C_TRACEPARENT_HEADER, traceHeader));
 
         assertThat(context).isEqualTo(PropagationContext.emptyContext());
     }
@@ -94,7 +95,7 @@ public class W3CPropagationCodecTest {
     public void GIVEN_aTraceHeaderWithInvalidSpanId_EXPECT_anEmptyContext() {
         final String traceHeader = "00-4cbc8d50f02449e887e8bc2aa8020d26-invalid-00";
 
-        final PropagationContext context = codec.decode(Map.of(W3CPropagationCodec.W3C_TRACEPARENT_HEADER, traceHeader));
+        final PropagationContext context = codec.decode(Collections.singletonMap(W3CPropagationCodec.W3C_TRACEPARENT_HEADER, traceHeader));
 
         assertThat(context).isEqualTo(PropagationContext.emptyContext());
     }
@@ -103,7 +104,7 @@ public class W3CPropagationCodecTest {
     public void GIVEN_aTraceHeaderWithInvalidTraceFlags_EXPECT_anEmptyContext() {
         final String traceHeader = "00-4cbc8d50f02449e887e8bc2aa8020d26-ace1ecab581fc069-invalid";
 
-        final PropagationContext context = codec.decode(Map.of(W3CPropagationCodec.W3C_TRACEPARENT_HEADER, traceHeader));
+        final PropagationContext context = codec.decode(Collections.singletonMap(W3CPropagationCodec.W3C_TRACEPARENT_HEADER, traceHeader));
 
         assertThat(context).isEqualTo(PropagationContext.emptyContext());
     }
@@ -124,7 +125,7 @@ public class W3CPropagationCodecTest {
         final Map<String, String> encoded = codec.encode(new PropagationContext(traceId, spanId, null, null)).get();
 
         assertThat(encoded).isEqualTo(
-            Map.of(W3CPropagationCodec.W3C_TRACEPARENT_HEADER, String.join("-", "00", traceId, spanId, "00"))
+            Collections.singletonMap(W3CPropagationCodec.W3C_TRACEPARENT_HEADER, String.join("-", "00", traceId, spanId, "00"))
         );
     }
 }

--- a/beeline-spring-boot-starter/src/main/java/io/honeycomb/beeline/spring/beans/BeelineRestTemplateInterceptor.java
+++ b/beeline-spring-boot-starter/src/main/java/io/honeycomb/beeline/spring/beans/BeelineRestTemplateInterceptor.java
@@ -11,6 +11,7 @@ import org.springframework.http.client.ClientHttpRequestInterceptor;
 import org.springframework.http.client.ClientHttpResponse;
 
 import java.io.IOException;
+import java.util.Map;
 import java.util.Optional;
 
 import static io.honeycomb.beeline.spring.utils.InstrumentationConstants.HTTP_CLIENT_SPAN_NAME;
@@ -86,6 +87,11 @@ public class BeelineRestTemplateInterceptor implements ClientHttpRequestIntercep
         @Override
         public Optional<String> getFirstHeader(String name) {
             return Optional.ofNullable(request.getHeaders().getFirst(name));
+        }
+
+        @Override
+        public Map<String, String> getHeaders() {
+            return request.getHeaders().toSingleValueMap();
         }
     }
 


### PR DESCRIPTION
This change refactors implementations of `PropagationCodec` (HoneyCombV1, W3C & AWS) to use a `Map<String, String>` instead of a single string value. This is so that we can read / write across multiple headers (eg traceparent & tracestate).

This also has the side effect of reducing the reliance of a particular codec's header being used directly and instead relies on the codec to finding / creating the headers it cares about.

~~**NOTE:** Creating this as draft while I have a couple of mocked tests to fix up in HttpServerPropagatorTest.~~
~~- [x] whenStartPropagation_traceIsStarted_andHttpFieldsAreApplied~~
~~- [x] whenStartPropagation_andNoTraceHeaderIsPresent_traceIsStarted_andHttpFieldsAreApplied~~

The PR consists of the following parts:
- Updating each `PropagationCodec` implementation to work with a Map<String, String> instead of a single String for use with HTTP header collections
- Add `HttpRequestAdapater` interface both servlet and HTTP client adapters implement to get access tot the request's HTTP header collection
- Update both implementations of servlet and http client interfaces to return the HTTP header collections
- Update associated tests to use Map<String, String> instead of single String