### PR TITLE
Use 'hny' for honeycomb propagation codec name

### DIFF
--- a/beeline-core/src/main/java/io/honeycomb/beeline/tracing/propagation/HttpHeaderV1PropagationCodec.java
+++ b/beeline-core/src/main/java/io/honeycomb/beeline/tracing/propagation/HttpHeaderV1PropagationCodec.java
@@ -37,7 +37,7 @@ public class HttpHeaderV1PropagationCodec implements PropagationCodec<Map<String
     private static final HttpHeaderV1PropagationCodec INSTANCE = new HttpHeaderV1PropagationCodec();
 
     // @formatter:off
-    protected static final String CODEC_NAME                = "honey";
+    protected static final String CODEC_NAME                = "hny";
     protected static final String HONEYCOMB_TRACE_HEADER    = "x-honeycomb-trace";
 
     private static final String TRACE_CONTEXT_VERSION_ONE   = "1";

--- a/beeline-spring-boot-starter/src/main/java/io/honeycomb/beeline/spring/autoconfig/BeelineProperties.java
+++ b/beeline-spring-boot-starter/src/main/java/io/honeycomb/beeline/spring/autoconfig/BeelineProperties.java
@@ -113,7 +113,7 @@ public class BeelineProperties {
      * default: honey
      * </p>
      */
-    private List<String> propagators = Collections.singletonList("honey");
+    private List<String> propagators = Collections.singletonList("hny");
 
     public String getDataset() {
         return dataset;

--- a/beeline-spring-boot-starter/src/test/java/io/honeycomb/beeline/spring/autoconfig/BeelineAutoconfigTest.java
+++ b/beeline-spring-boot-starter/src/test/java/io/honeycomb/beeline/spring/autoconfig/BeelineAutoconfigTest.java
@@ -340,7 +340,7 @@ public class BeelineAutoconfigTest {
             .withConfiguration(AutoConfigurations.of(BeelineAutoconfig.class))
             .withPropertyValues(defaultProps)
             .run(context -> {
-                assertThat(context.getBean(BeelineProperties.class).getPropagators()).isEqualTo(Collections.singletonList("honey"));
+                assertThat(context.getBean(BeelineProperties.class).getPropagators()).isEqualTo(Collections.singletonList("hny"));
             });
     }
 
@@ -349,9 +349,9 @@ public class BeelineAutoconfigTest {
         webApplicationContextRunner
             .withConfiguration(AutoConfigurations.of(BeelineAutoconfig.class))
             .withPropertyValues(defaultProps)
-            .withPropertyValues("honeycomb.beeline.propagators=honey,w3c")
+            .withPropertyValues("honeycomb.beeline.propagators=hny,w3c")
             .run(context -> {
-                assertThat(context.getBean(BeelineProperties.class).getPropagators()).containsExactly("honey", "w3c");
+                assertThat(context.getBean(BeelineProperties.class).getPropagators()).containsExactly("hny", "w3c");
             });
     }
 }


### PR DESCRIPTION
Switch to use abbreviated codec name.