### PR TITLE
Add parse and propagation hooks

### DIFF
--- a/beeline-core/src/main/java/io/honeycomb/beeline/tracing/propagation/BeelineServletFilter.java
+++ b/beeline-core/src/main/java/io/honeycomb/beeline/tracing/propagation/BeelineServletFilter.java
@@ -99,10 +99,9 @@ public class BeelineServletFilter implements Filter {
         this.pathMatcher = pathMatcher;
         this.spanRequestFieldsCustomizer = new HttpServerRequestSpanCustomizer();
         this.requestToRedispatchSpanName = requestToRedispatchSpanName;
-        this.httpServerPropagator = new HttpServerPropagator(beeline,
-            serviceName,
-            requestToSpanName,
-            propagationCodec);
+        this.httpServerPropagator = new HttpServerPropagator.Builder(beeline, serviceName, requestToSpanName)
+                                        .setPropagationCodec(propagationCodec)
+                                        .build();
     }
 
     @Override

--- a/beeline-core/src/main/java/io/honeycomb/beeline/tracing/propagation/BeelineServletFilter.java
+++ b/beeline-core/src/main/java/io/honeycomb/beeline/tracing/propagation/BeelineServletFilter.java
@@ -100,8 +100,8 @@ public class BeelineServletFilter implements Filter {
         this.spanRequestFieldsCustomizer = new HttpServerRequestSpanCustomizer();
         this.requestToRedispatchSpanName = requestToRedispatchSpanName;
         this.httpServerPropagator = new HttpServerPropagator.Builder(beeline, serviceName, requestToSpanName)
-                                        .setPropagationCodec(propagationCodec)
-                                        .build();
+            .setPropagationCodec(propagationCodec)
+            .build();
     }
 
     @Override

--- a/beeline-core/src/main/java/io/honeycomb/beeline/tracing/propagation/HttpClientPropagator.java
+++ b/beeline-core/src/main/java/io/honeycomb/beeline/tracing/propagation/HttpClientPropagator.java
@@ -56,7 +56,7 @@ public class HttpClientPropagator {
         this(tracer, Propagation.honeycombHeaderV1(), requestToSpanName, null);
     }
 
-    // User by builder
+    // Used by builder
     protected HttpClientPropagator(final Tracer tracer,
                                 final PropagationCodec<Map<String, String>> propagationCodec,
                                 final Function<HttpClientRequestAdapter, String> requestToSpanName,

--- a/beeline-core/src/main/java/io/honeycomb/beeline/tracing/propagation/HttpClientPropagator.java
+++ b/beeline-core/src/main/java/io/honeycomb/beeline/tracing/propagation/HttpClientPropagator.java
@@ -55,17 +55,8 @@ public class HttpClientPropagator {
         this(tracer, Propagation.honeycombHeaderV1(), requestToSpanName, null);
     }
 
-    /**
-     * Create an HttpClientPropagator for tracing HTTP client requests.
-     * {@code requestToSpanName} allows you to dynamically name the HTTP client spans such that the name
-     * reflects the operation, e.g. based on HTTP method or request path used.
-     *
-     * @param tracer the tracer
-     * @param propagationCodec the propagation codec to use for parsing and propagating trace data
-     * @param requestToSpanName a function from request to span name
-     * @param propagateHook a custom function to propagate the Propagation Context into HTTP headers
-     */
-    public HttpClientPropagator(final Tracer tracer,
+    // User by builder
+    protected HttpClientPropagator(final Tracer tracer,
                                 final PropagationCodec<Map<String, String>> propagationCodec,
                                 final Function<HttpClientRequestAdapter, String> requestToSpanName,
                                 final Function<HttpClientRequestAdapter, Optional<Map<String, String>>> propagateHook) {

--- a/beeline-core/src/main/java/io/honeycomb/beeline/tracing/propagation/HttpClientPropagator.java
+++ b/beeline-core/src/main/java/io/honeycomb/beeline/tracing/propagation/HttpClientPropagator.java
@@ -40,7 +40,7 @@ public class HttpClientPropagator {
     private final Tracer tracer;
     private final PropagationCodec<Map<String, String>> propagationCodec;
     private final Function<HttpClientRequestAdapter, String> requestToSpanName;
-    private Function<HttpClientRequestAdapter, Optional<Map<String, String>>> propagationHook = null;
+    private final Function<HttpClientRequestAdapter, Optional<Map<String, String>>> propagationHook;
 
     /**
      * Create an HttpClientPropagator for tracing HTTP client requests.

--- a/beeline-core/src/main/java/io/honeycomb/beeline/tracing/propagation/HttpClientPropagator.java
+++ b/beeline-core/src/main/java/io/honeycomb/beeline/tracing/propagation/HttpClientPropagator.java
@@ -147,4 +147,52 @@ public class HttpClientPropagator {
             childSpan.addField(CLIENT_REQUEST_ERROR_DETAIL_FIELD, ex.getMessage());
         }
     }
+
+    /**
+     * Builder for {@link HttpClientPropagator}.
+     */
+    public static class Builder {
+        private Tracer tracer;
+        private Function<HttpClientRequestAdapter, String> requestToSpanName;
+        private PropagationCodec<Map<String, String>> propagationCodec = Propagation.honeycombHeaderV1();
+        private Function<HttpClientRequestAdapter, Optional<Map<String, String>>> propagateHook = null;
+
+        /**
+         * Creates a new instance of {@link HttpClientPropagator.Builder}.
+         * @param tracer the tracer
+         * @param requestToSpanName a function from request to span name
+         */
+        public Builder(Tracer tracer, Function<HttpClientRequestAdapter, String> requestToSpanName) {
+            this.tracer = tracer;
+            this.requestToSpanName = requestToSpanName;
+        }
+
+        /**
+         * Set the {@link PropagationCodec} to encode/decode trace context via HTTP headers.
+         * @param propagationCodec
+         * @return this
+         */
+        public Builder setPropagationCodec(PropagationCodec<Map<String, String>> propagationCodec) {
+            this.propagationCodec = propagationCodec;
+            return this;
+        }
+
+        /**
+         * Set the custom function that
+         * @param propagationHook
+         * @return this
+         */
+        public Builder setPropagateHook(Function<HttpClientRequestAdapter, Optional<Map<String, String>>> propagationHook) {
+            this.propagateHook = propagationHook;
+            return this;
+        }
+
+        /**
+         * Builds a {@link HttpClientPropagator} using the parameters passed.
+         * @return a new instance of {@link HttpClientPropagator}
+         */
+        public HttpClientPropagator build() {
+            return new HttpClientPropagator(tracer, propagationCodec, requestToSpanName, propagateHook);
+        }
+    }
 }

--- a/beeline-core/src/main/java/io/honeycomb/beeline/tracing/propagation/HttpClientPropagator.java
+++ b/beeline-core/src/main/java/io/honeycomb/beeline/tracing/propagation/HttpClientPropagator.java
@@ -152,6 +152,7 @@ public class HttpClientPropagator {
      * Builder for {@link HttpClientPropagator}.
      */
     public static class Builder {
+
         private Tracer tracer;
         private Function<HttpClientRequestAdapter, String> requestToSpanName;
         private PropagationCodec<Map<String, String>> propagationCodec = Propagation.honeycombHeaderV1();
@@ -160,7 +161,7 @@ public class HttpClientPropagator {
         /**
          * Creates a new instance of {@link HttpClientPropagator.Builder}.
          * @param tracer the tracer
-         * @param requestToSpanName a function from request to span name
+         * @param requestToSpanName function to get a span name from a {@link HttpClientRequestAdapter}
          */
         public Builder(Tracer tracer, Function<HttpClientRequestAdapter, String> requestToSpanName) {
             this.tracer = tracer;
@@ -170,7 +171,7 @@ public class HttpClientPropagator {
         /**
          * Set the {@link PropagationCodec} to encode/decode trace context via HTTP headers.
          * @param propagationCodec
-         * @return this
+         * @return the {@link HttpClientPropagator.Builder} to be used for chaining
          */
         public Builder setPropagationCodec(PropagationCodec<Map<String, String>> propagationCodec) {
             this.propagationCodec = propagationCodec;
@@ -178,9 +179,9 @@ public class HttpClientPropagator {
         }
 
         /**
-         * Set the custom function that
+         * Set a custom function used to parse trace context on incoming HTTP requests.
          * @param propagationHook
-         * @return this
+         * @return the {@link HttpClientPropagator.Builder} to be used for chaining
          */
         public Builder setPropagateHook(Function<HttpClientRequestAdapter, Optional<Map<String, String>>> propagationHook) {
             this.propagateHook = propagationHook;

--- a/beeline-core/src/test/java/io/honeycomb/beeline/tracing/propagation/HttpClientPropagatorTest.java
+++ b/beeline-core/src/test/java/io/honeycomb/beeline/tracing/propagation/HttpClientPropagatorTest.java
@@ -34,7 +34,7 @@ public class HttpClientPropagatorTest {
     @Mock
     private PropagationCodec<Map<String, String>> mockPropagationCodec;
     @Mock
-    private Function<HttpClientRequestAdapter, Optional<Map<String, String>>> mockEncodeFunc;
+    private Function<HttpClientRequestAdapter, Optional<Map<String, String>>> mockTracePropagationHook;
 
     private HttpClientPropagator httpClientPropagator;
 
@@ -134,14 +134,13 @@ public class HttpClientPropagatorTest {
         when(mockHttpRequest.getPath()).thenReturn(Optional.empty());
         when(mockHttpRequest.getContentLength()).thenReturn(0);
         when(mockHttpRequest.getMethod()).thenReturn("GET");
-
-        when(mockEncodeFunc.apply(mockHttpRequest)).thenReturn(Optional.empty());
+        when(mockTracePropagationHook.apply(mockHttpRequest)).thenReturn(Optional.empty());
 
         final HttpClientPropagator propagator = new HttpClientPropagator.Builder(mockTracer, r -> EXPECTED_SPAN_NAME)
-            .setPropagateHook(mockEncodeFunc)
+            .setTracePropagationHook(mockTracePropagationHook)
             .build();
         propagator.startPropagation(mockHttpRequest);
-        verify(mockEncodeFunc, times(1)).apply(mockHttpRequest);
+        verify(mockTracePropagationHook, times(1)).apply(mockHttpRequest);
         verify(mockPropagationCodec, times(0)).encode(any(PropagationContext.class));
     }
 

--- a/beeline-core/src/test/java/io/honeycomb/beeline/tracing/propagation/HttpClientPropagatorTest.java
+++ b/beeline-core/src/test/java/io/honeycomb/beeline/tracing/propagation/HttpClientPropagatorTest.java
@@ -33,6 +33,8 @@ public class HttpClientPropagatorTest {
     private HttpClientResponseAdapter mockHttpResponse;
     @Mock
     private PropagationCodec<Map<String, String>> mockPropagationCodec;
+    @Mock
+    private Function<HttpClientRequestAdapter, Optional<Map<String, String>>> mockEncodeFunc;
 
     private HttpClientPropagator httpClientPropagator;
 
@@ -123,7 +125,6 @@ public class HttpClientPropagatorTest {
     }
 
     @Test
-    @SuppressWarnings("unchecked")
     public void GIVEN_propagateIsNotNull_EXPECT_hookToBeUsedInsteadOfPropagationCodec() {
 
         when(mockTracer.startChildSpan(EXPECTED_SPAN_NAME)).thenReturn(mockSpan);
@@ -132,7 +133,6 @@ public class HttpClientPropagatorTest {
         when(mockHttpRequest.getContentLength()).thenReturn(0);
         when(mockHttpRequest.getMethod()).thenReturn("GET");
 
-        final Function<HttpClientRequestAdapter, Optional<Map<String, String>>> mockEncodeFunc = (Function<HttpClientRequestAdapter, Optional<Map<String, String>>>) mock(Function.class);
         when(mockEncodeFunc.apply(mockHttpRequest)).thenReturn(Optional.empty());
 
         final HttpClientPropagator propagator = new HttpClientPropagator(mockTracer, mockPropagationCodec, r -> EXPECTED_SPAN_NAME, mockEncodeFunc);

--- a/beeline-core/src/test/java/io/honeycomb/beeline/tracing/propagation/HttpClientPropagatorTest.java
+++ b/beeline-core/src/test/java/io/honeycomb/beeline/tracing/propagation/HttpClientPropagatorTest.java
@@ -12,7 +12,7 @@ import org.mockito.junit.MockitoJUnitRunner;
 import java.util.Collections;
 import java.util.Map;
 import java.util.Optional;
-import java.util.function.Function;
+import java.util.function.BiFunction;
 
 import static io.honeycomb.beeline.tracing.propagation.MockSpanUtils.stubFluentCalls;
 import static io.honeycomb.beeline.tracing.utils.TraceFieldConstants.*;
@@ -34,7 +34,7 @@ public class HttpClientPropagatorTest {
     @Mock
     private PropagationCodec<Map<String, String>> mockPropagationCodec;
     @Mock
-    private Function<HttpClientRequestAdapter, Optional<Map<String, String>>> mockTracePropagationHook;
+    private BiFunction<HttpClientRequestAdapter, PropagationContext, Optional<Map<String, String>>> mockTracePropagationHook;
 
     private HttpClientPropagator httpClientPropagator;
 
@@ -134,13 +134,14 @@ public class HttpClientPropagatorTest {
         when(mockHttpRequest.getPath()).thenReturn(Optional.empty());
         when(mockHttpRequest.getContentLength()).thenReturn(0);
         when(mockHttpRequest.getMethod()).thenReturn("GET");
-        when(mockTracePropagationHook.apply(mockHttpRequest)).thenReturn(Optional.empty());
+        when(mockSpan.getTraceContext()).thenReturn(PropagationContext.emptyContext());
+        when(mockTracePropagationHook.apply(mockHttpRequest, PropagationContext.emptyContext())).thenReturn(Optional.empty());
 
         final HttpClientPropagator propagator = new HttpClientPropagator.Builder(mockTracer, r -> EXPECTED_SPAN_NAME)
             .setTracePropagationHook(mockTracePropagationHook)
             .build();
         propagator.startPropagation(mockHttpRequest);
-        verify(mockTracePropagationHook, times(1)).apply(mockHttpRequest);
+        verify(mockTracePropagationHook, times(1)).apply(mockHttpRequest, PropagationContext.emptyContext());
         verify(mockPropagationCodec, times(0)).encode(any(PropagationContext.class));
     }
 

--- a/beeline-core/src/test/java/io/honeycomb/beeline/tracing/propagation/HttpClientPropagatorTest.java
+++ b/beeline-core/src/test/java/io/honeycomb/beeline/tracing/propagation/HttpClientPropagatorTest.java
@@ -41,7 +41,9 @@ public class HttpClientPropagatorTest {
     @Before
     public void setUp() {
         stubFluentCalls(mockSpan);
-        httpClientPropagator = new HttpClientPropagator(mockTracer, mockPropagationCodec, r -> EXPECTED_SPAN_NAME, null);
+        httpClientPropagator = new HttpClientPropagator.Builder(mockTracer, r -> EXPECTED_SPAN_NAME)
+            .setPropagationCodec(mockPropagationCodec)
+            .build();
     }
 
     @Test
@@ -135,7 +137,9 @@ public class HttpClientPropagatorTest {
 
         when(mockEncodeFunc.apply(mockHttpRequest)).thenReturn(Optional.empty());
 
-        final HttpClientPropagator propagator = new HttpClientPropagator(mockTracer, mockPropagationCodec, r -> EXPECTED_SPAN_NAME, mockEncodeFunc);
+        final HttpClientPropagator propagator = new HttpClientPropagator.Builder(mockTracer, r -> EXPECTED_SPAN_NAME)
+            .setPropagateHook(mockEncodeFunc)
+            .build();
         propagator.startPropagation(mockHttpRequest);
         verify(mockEncodeFunc, times(1)).apply(mockHttpRequest);
         verify(mockPropagationCodec, times(0)).encode(any(PropagationContext.class));

--- a/beeline-core/src/test/java/io/honeycomb/beeline/tracing/propagation/HttpServerPropagatorTest.java
+++ b/beeline-core/src/test/java/io/honeycomb/beeline/tracing/propagation/HttpServerPropagatorTest.java
@@ -138,7 +138,6 @@ public class HttpServerPropagatorTest {
         when(mockHttpRequest.getPath()).thenReturn(Optional.empty());
         when(mockHttpRequest.getContentLength()).thenReturn(0);
         when(mockHttpRequest.getMethod()).thenReturn("GET");
-
         when(mockTraceParserHook.apply(mockHttpRequest)).thenReturn(PropagationContext.emptyContext());
 
         final HttpServerPropagator propagator = new HttpServerPropagator.Builder(mockBeeline, EXPECTED_SERVICE_NAME, REQUEST_TO_SPAN_NAME)

--- a/beeline-core/src/test/java/io/honeycomb/beeline/tracing/propagation/HttpServerPropagatorTest.java
+++ b/beeline-core/src/test/java/io/honeycomb/beeline/tracing/propagation/HttpServerPropagatorTest.java
@@ -36,7 +36,7 @@ public class HttpServerPropagatorTest {
     @Mock
     private PropagationContext mockPropagationContext;
     @Mock
-    private Function<HttpServerRequestAdapter, PropagationContext> mockParseTraceHook;
+    private Function<HttpServerRequestAdapter, PropagationContext> mockTraceParserHook;
 
     private HttpServerPropagator httpServerPropagator;
 
@@ -130,7 +130,7 @@ public class HttpServerPropagatorTest {
     }
 
     @Test
-    public void GIVEN_parseTraceHookIsNotNull_EXPECT_hookToBeUsedInsteadOfPropagationCodec() {
+    public void GIVEN_traceParserHookHookIsNotNull_EXPECT_hookToBeUsedInsteadOfPropagationCodec() {
 
         // when(mockTracer.startChildSpan(EXPECTED_SPAN_NAME)).thenReturn(mockSpan);
         when(mockBeeline.startTrace(EXPECTED_SPAN_NAME, PropagationContext.emptyContext(), EXPECTED_SERVICE_NAME)).thenReturn(mockSpan);
@@ -139,14 +139,14 @@ public class HttpServerPropagatorTest {
         when(mockHttpRequest.getContentLength()).thenReturn(0);
         when(mockHttpRequest.getMethod()).thenReturn("GET");
 
-        when(mockParseTraceHook.apply(mockHttpRequest)).thenReturn(PropagationContext.emptyContext());
+        when(mockTraceParserHook.apply(mockHttpRequest)).thenReturn(PropagationContext.emptyContext());
 
         final HttpServerPropagator propagator = new HttpServerPropagator.Builder(mockBeeline, EXPECTED_SERVICE_NAME, REQUEST_TO_SPAN_NAME)
-            .setParseTraceHook(mockParseTraceHook)
+            .setTraceParserHook(mockTraceParserHook)
             .build();
         final Span span = propagator.startPropagation(mockHttpRequest);
         assertThat(span).isSameAs(mockSpan);
-        verify(mockParseTraceHook, times(1)).apply(mockHttpRequest);
+        verify(mockTraceParserHook, times(1)).apply(mockHttpRequest);
         verify(mockPropagationCodec, times(0)).encode(any(PropagationContext.class));
     }
 

--- a/beeline-core/src/test/java/io/honeycomb/beeline/tracing/propagation/HttpServerPropagatorTest.java
+++ b/beeline-core/src/test/java/io/honeycomb/beeline/tracing/propagation/HttpServerPropagatorTest.java
@@ -48,9 +48,9 @@ public class HttpServerPropagatorTest {
     public void setup() {
         stubFluentCalls(mockSpan);
         httpServerPropagator = new HttpServerPropagator.Builder(mockBeeline, EXPECTED_SERVICE_NAME, REQUEST_TO_SPAN_NAME)
-                                                    .setSpanCustomizer(mockSpanCustomizer)
-                                                    .setPropagationCodec(mockPropagationCodec)
-                                                    .build();
+            .setSpanCustomizer(mockSpanCustomizer)
+            .setPropagationCodec(mockPropagationCodec)
+            .build();
     }
 
     @Test

--- a/beeline-spring-boot-starter/src/main/java/io/honeycomb/beeline/spring/beans/BeelineRestTemplateInterceptor.java
+++ b/beeline-spring-boot-starter/src/main/java/io/honeycomb/beeline/spring/beans/BeelineRestTemplateInterceptor.java
@@ -32,7 +32,9 @@ public class BeelineRestTemplateInterceptor implements ClientHttpRequestIntercep
     public BeelineRestTemplateInterceptor(final Tracer tracer, PropagationCodec<Map<String, String>> propagationCodec) {
         Assert.notNull(tracer, "Validation failed: tracer must not be null");
         Assert.notNull(propagationCodec, "Validation failed: propagationCodec must not be null");
-        this.httpClientPropagator = new HttpClientPropagator(tracer, propagationCodec, r -> HTTP_CLIENT_SPAN_NAME, null);
+        this.httpClientPropagator = new HttpClientPropagator.Builder(tracer, r -> HTTP_CLIENT_SPAN_NAME)
+            .setPropagationCodec(propagationCodec)
+            .build();
     }
 
     @Override

--- a/beeline-spring-boot-starter/src/main/java/io/honeycomb/beeline/spring/beans/BeelineRestTemplateInterceptor.java
+++ b/beeline-spring-boot-starter/src/main/java/io/honeycomb/beeline/spring/beans/BeelineRestTemplateInterceptor.java
@@ -32,7 +32,7 @@ public class BeelineRestTemplateInterceptor implements ClientHttpRequestIntercep
     public BeelineRestTemplateInterceptor(final Tracer tracer, PropagationCodec<Map<String, String>> propagationCodec) {
         Assert.notNull(tracer, "Validation failed: tracer must not be null");
         Assert.notNull(propagationCodec, "Validation failed: propagationCodec must not be null");
-        this.httpClientPropagator = new HttpClientPropagator(tracer, propagationCodec, r -> HTTP_CLIENT_SPAN_NAME);
+        this.httpClientPropagator = new HttpClientPropagator(tracer, propagationCodec, r -> HTTP_CLIENT_SPAN_NAME, null);
     }
 
     @Override


### PR DESCRIPTION
Adds `HttpClientPropgator.tracePropagationHook` and `HttpServerPropagator.traceParserHook` to provide custom functions consumers of the beeline can use to manage trace context on incoming / outgoing HTTP requests.

Also includes a builder classes to make it easier configure the HttpClientPropagator & HttpServerPropagator with optional parameters.

Example of setting up a propagation hook to set HTTP headers using the W3C format on outgoing requests:
```java
final HttpClientPropagator propagator = new HttpClientPropagator.Builder(tracer, r -> "span-name")
    .setTracePropagationHook((request, context) -> {
        return Propagation.w3c().encode(mockContext);
    })
    .build();
```

Example of setting a parser hook to extract a propagation context from an incoming HTTP request that first tries the W3C then falls back to honeycomb:
```java
final HttpServerPropagator propagator = new HttpServerPropagator.Builder(beeline, "my-sevice", r -> "span-name")
    .setParsePropagationHook(request -> {
        PropagationContext context = Propagation.w3c.decode(request.getHeaders());
        if (context != PropagationContext.emptyContext()) {
            return context;
        }

        return Propagation.honey().decode(request.getHeaders());
    })
    .build();
```