### PR TITLE
Add config metadata for beeline properties

### DIFF
--- a/beeline-spring-boot-starter/src/main/resources/META-INF/spring-configuration-metadata.json
+++ b/beeline-spring-boot-starter/src/main/resources/META-INF/spring-configuration-metadata.json
@@ -1,0 +1,85 @@
+{
+  "groups":[
+    {
+      "name":"honeycomb.beeline",
+      "type":"io.honeycomb.beeline.spring.autoconfig.BeelineProperties"
+    }
+  ],
+  "properties":[
+    {
+      "name":"honeycomb.beeline.enabled",
+      "type":"java.lang.Boolean",
+      "description":"Determines if the beeline is enabled or not.",
+      "defaultValue":"true"
+    },
+    {
+      "name":"honeycomb.beeline.writeKey",
+      "type":"java.lang.String",
+      "description":"WriteKey is the Honeycomb authentication token."
+    },
+    {
+      "name":"honeycomb.beeline.dataset",
+      "type":"java.lang.String",
+      "description":"Dataset is the name of the Honeycomb dataset to which to send Beeline spans and events."
+    },
+    {
+      "name":"honeycomb.beeline.apiHost",
+      "type":"java.net.URI",
+      "description":"APIHost is the hostname for the Honeycomb API server to which to send events.",
+      "defaultValue":"https://api.honeycomb.io/"
+    },
+    {
+      "name":"honeycomb.beeline.serviceName",
+      "type":"java.lang.String",
+      "description":"A name to identify this service when tracing data is displayed within Honeycomb. If not set, this will try to fall back to using Spring's own \"spring.application.name\" property."
+    },
+    {
+      "name":"honeycomb.beeline.sampleRate",
+      "type":"java.lang.Integer",
+      "description":"The sampleRate is the rate at which to sample traces - based on the \"traceId\". The sample probability is 1/{sampleRate}.",
+      "defaultValue":"1"
+    },
+    {
+      "name":"honeycomb.beeline.filterOrder",
+      "type":"java.lang.Integer",
+      "description":"Setting this will change the Beeline's Servlet Filter order. This might be useful, for example, when your application makes use of a security filter and rejected requests should not be captured by the beeline.",
+      "defaultValue":"org.springframework.core.Ordered.HIGHEST_PRECEDENCE"
+    },
+    {
+      "name":"honeycomb.beeline.logHoneycombResponses",
+      "type":"java.lang.Boolean",
+      "description":"This toggles whether to log the Honeycomb server's responses to Events and Spans being sent.",
+      "defaultValue":"true"
+    },
+    {
+      "name":"honeycomb.beeline.includePathPatterns",
+      "type":"java.lang.String",
+      "description":"Comma-separated list of Ant-style path patterns that are used to match against the request path of incoming HTTP requests. If a request path is matched against this list then the request will be instrumented by the Beeline.",
+      "defaultValue":""
+    },
+    {
+      "name":"honeycomb.beeline.excludePathPatterns",
+      "type":"java.lang.String",
+      "description":"Comma-separated list of Ant-style path patterns that are used to match against the request path of incoming HTTP requests. If a request path is matched agains this list then the request will NOT be instrumented by the Beeline.",
+      "defaultValue":""
+    },
+    {
+      "name":"honeycomb.beeline.propagators",
+      "type":"java.lang.String",
+      "description":"Comma-separated list of propagators to use for parsing incoming and propagate out trace information.",
+      "defaultValue":"hny"
+    },
+    {
+      "name":"honeycomb.beeline.rest-template.enabled",
+      "type":"java.lang.Boolean",
+      "description":"Toggles whether the HttpClient rest template instrumentation is enabled.",
+      "defaultValue":"true"
+    },
+    {
+      "name":"honeycomb.beeline.jdbc.enabled",
+      "type":"java.lang.Boolean",
+      "description":"Toggles whether the JDBC instrumentation is enabled.",
+      "defaultValue":"true"
+    }
+  ]
+}


### PR DESCRIPTION
Fixes #55 (@kvrhdn).

Adds metadata to describe config properties used in both `BeelineProperties` and `BeelineAutoconfig`.