### PR TITLE
Bump maven-javadoc-plugin to v3.2.0

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -85,7 +85,7 @@
         <compilerPluginVersion>3.7.0</compilerPluginVersion>
         <reportsPluginVersion>2.9</reportsPluginVersion>
         <mavenSourcePluginVersion>3.0.1</mavenSourcePluginVersion>
-        <javadocPluginVersion>3.0.0</javadocPluginVersion>
+        <javadocPluginVersion>3.2.0</javadocPluginVersion>
         <xrefPluginVersion>2.5</xrefPluginVersion>
         <mavenWrapperPluginVersion>0.6.0</mavenWrapperPluginVersion>
         <pmdPluginVersion>3.9.0</pmdPluginVersion>


### PR DESCRIPTION
Bump `maven-javadoc-plugin` version to latest (v3.2.0).

We were seeing some unusual errors on the previous version (v3.0.0) related to NullPointerExceptions when trying to package the projects. This was resolved in [MJAVADOC-517](https://issues.apache.org/jira/browse/MJAVADOC-517) that was part of release v3.0.1.