### PR TITLE
Remove extra package job from build workflow

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -15,7 +15,6 @@ commands:
           paths:
             - ~/.m2
           key: beeline-java-{{ checksum "pom.xml" }}-<< parameters.javaversion >>
-      - run: ./mvnw package # run the actual tests
 executors:
   java:
     parameters:


### PR DESCRIPTION
After moving the package step into line 13 in #70, we no longer need a separate `package` step. This is causing our build times to double unnecessarily.