### PR TITLE
Add support for configuring a proxy via spring boot AutoConf settings

### DIFF
--- a/beeline-spring-boot-starter/src/main/java/io/honeycomb/beeline/spring/autoconfig/BeelineProperties.java
+++ b/beeline-spring-boot-starter/src/main/java/io/honeycomb/beeline/spring/autoconfig/BeelineProperties.java
@@ -115,6 +115,21 @@ public class BeelineProperties {
      */
     private List<String> propagators = Collections.singletonList("hny");
 
+    /**
+     * The hostname of a HTTP proxy if one is to be used with the Beeline to send events.
+     */
+    private String proxyHostname = "";
+
+    /**
+     * The username for a HTTP proxy if one is to be used with the Beeline to send events.
+     */
+    private String proxyUsername = "";
+
+    /**
+     * The password for a HTTP proxy if one is to be used with the Beeline to send events.
+     */
+    private String proxyPassword = "";
+
     public String getDataset() {
         return dataset;
     }
@@ -211,6 +226,30 @@ public class BeelineProperties {
         this.propagators = propagators;
     }
 
+    public String getProxyHostname() {
+        return proxyHostname;
+    }
+
+    public void setProxyHostname(String hostname) {
+        this.proxyHostname = hostname;
+    }
+
+    public String getProxyUsername() {
+        return proxyUsername;
+    }
+
+    public void setProxyUsername(String username) {
+        this.proxyUsername = username;
+    }
+
+    public String getProxyPassword() {
+        return proxyPassword;
+    }
+
+    public void setProxyPassword(String password) {
+        this.proxyPassword = password;
+    }
+
     public static class RestTemplateProperties {
         /**
          * When set to false, this will disable the configuration of beans related to RestTemplate instrumentation,
@@ -248,6 +287,9 @@ public class BeelineProperties {
                ", excludePathPatterns=" + excludePathPatterns +
                ", restTemplate=" + restTemplate +
                ", propagators=" + String.join(",", propagators) +
+               ", proxyHostname='" + proxyHostname + "'" +
+               ", proxyUsername='" + proxyUsername + "'" +
+               ", proxyPassword='" + proxyPassword + "'" +
                '}';
     }
 }

--- a/beeline-spring-boot-starter/src/main/resources/META-INF/spring-configuration-metadata.json
+++ b/beeline-spring-boot-starter/src/main/resources/META-INF/spring-configuration-metadata.json
@@ -80,6 +80,24 @@
       "type":"java.lang.Boolean",
       "description":"Toggles whether the JDBC instrumentation is enabled.",
       "defaultValue":"true"
+    },
+    {
+      "name":"honeycomb.beeline.proxyHostname",
+      "type":"java.lang.String",
+      "description":"The hostname of a proxy to be used to send events to Honeycomb. An empty value means the Beeline does not configure a proxy and sends events directly to Honeycomb.",
+      "defaultValue":""
+    },
+    {
+      "name":"honeycomb.beeline.proxyUsername",
+      "type":"java.lang.String",
+      "description":"The username to be used for connecting to a proxy.",
+      "defaultValue":""
+    },
+    {
+      "name":"honeycomb.beeline.proxyPassword",
+      "type":"java.lang.String",
+      "description":"The password to be used for connecting to a proxy.",
+      "defaultValue":""
     }
   ]
 }

--- a/beeline-spring-boot-starter/src/test/java/io/honeycomb/beeline/spring/autoconfig/BeelineAutoconfigTest.java
+++ b/beeline-spring-boot-starter/src/test/java/io/honeycomb/beeline/spring/autoconfig/BeelineAutoconfigTest.java
@@ -95,6 +95,9 @@ public class BeelineAutoconfigTest {
                 assertThat(Objects.requireNonNull(context.getBean(BeelineProperties.class).getApiHost()).toString()).isEqualTo("http://localhost:9111/events");
                 assertThat(context.getBean(BeelineProperties.class).getServiceName()).isEqualTo("TestService");
                 assertThat(context.getBean(BeelineProperties.class).isEnabled()).isTrue();
+                assertThat(context.getBean(BeelineProperties.class).getProxyHostname()).isEmpty();
+                assertThat(context.getBean(BeelineProperties.class).getProxyUsername()).isEmpty();
+                assertThat(context.getBean(BeelineProperties.class).getProxyPassword()).isEmpty();
             });
     }
 
@@ -352,6 +355,24 @@ public class BeelineAutoconfigTest {
             .withPropertyValues("honeycomb.beeline.propagators=hny,w3c")
             .run(context -> {
                 assertThat(context.getBean(BeelineProperties.class).getPropagators()).containsExactly("hny", "w3c");
+            });
+    }
+
+    @Test
+    public void GIVEN_proxySettings_EXPECT_providedProxySettingsToBeUsed() {
+        final String hostname = "http://my-proxy.local";
+        final String username = "my-username";
+        final String password = "my-password";
+        webApplicationContextRunner
+            .withConfiguration(AutoConfigurations.of(BeelineAutoconfig.class))
+            .withPropertyValues(defaultProps)
+            .withPropertyValues("honeycomb.beeline.proxyHostname=" + hostname)
+            .withPropertyValues("honeycomb.beeline.proxyUsername=" + username)
+            .withPropertyValues("honeycomb.beeline.proxyPassword=" + password)
+            .run(context -> {
+                assertThat(context.getBean(BeelineProperties.class).getProxyHostname()).isEqualTo(hostname);
+                assertThat(context.getBean(BeelineProperties.class).getProxyUsername()).isEqualTo(username);
+                assertThat(context.getBean(BeelineProperties.class).getProxyPassword()).isEqualTo(password);
             });
     }
 }


### PR DESCRIPTION
Adds support for configuring a proxy via SpringBoot's AutoConf settings. The username and password can be optionally set if required.

Use proxy without username / password:
```
honeycomb.beeline.proxyHostname=http://localhost:1234
```

Use proxy with username & password:
```
honeycomb.beeline.proxyHostname=http://localhost:1234
honeycomb.beeline.proxyUsername=username
honeycomb.beeline.proxyPassword=password
```