### PR TITLE
Add tracestate parsing / propagation to W3C codec

### DIFF
--- a/beeline-core/src/main/java/io/honeycomb/beeline/tracing/propagation/W3CPropagationCodec.java
+++ b/beeline-core/src/main/java/io/honeycomb/beeline/tracing/propagation/W3CPropagationCodec.java
@@ -173,12 +173,7 @@ public class W3CPropagationCodec implements PropagationCodec<Map<String, String>
             return Optional.empty();
         }
 
-        final String traceParent = new StringBuilder(HEADER_LENGTH)
-            .append(DEFAULT_VERSION).append(SEGMENT_SEPARATOR)
-            .append(context.getTraceId()).append(SEGMENT_SEPARATOR)
-            .append(context.getSpanId()).append(SEGMENT_SEPARATOR)
-            .append(NOT_SAMPLED_TRACEFLAGS)
-            .toString();
+        final String traceParent = String.join(SEGMENT_SEPARATOR, DEFAULT_VERSION, context.getTraceId(), context.getSpanId(), NOT_SAMPLED_TRACEFLAGS);
 
         // If no dataset or tracefields, just return trace parent header
         if (context.getDataset() == null && context.getTraceFields().isEmpty()) {

--- a/beeline-core/src/main/java/io/honeycomb/beeline/tracing/propagation/W3CPropagationCodec.java
+++ b/beeline-core/src/main/java/io/honeycomb/beeline/tracing/propagation/W3CPropagationCodec.java
@@ -188,11 +188,11 @@ public class W3CPropagationCodec implements PropagationCodec<Map<String, String>
         }
 
         final boolean[] first = {true}; // trick for allowing scoped variables to be accessed inside lambda functions
-        final StringBuilder traceState = new StringBuilder();
+        final StringBuilder builder = new StringBuilder();
 
         // If not null, add dataset first
         if (context.getDataset() != null && !context.getDataset().isEmpty()) {
-            traceState.append(String.join(TRACESTATE_VALUE_SEPARATOR, DATASET_STRING, context.getDataset()));
+            builder.append(String.join(TRACESTATE_VALUE_SEPARATOR, DATASET_STRING, context.getDataset()));
             first[0] = false;
         }
 
@@ -201,15 +201,16 @@ public class W3CPropagationCodec implements PropagationCodec<Map<String, String>
             .sorted(Map.Entry.<String, Object>comparingByKey())
             .forEach(field -> {
                 if (!first[0]) {
-                    traceState.append(TRACESTATE_VENDOR_SEPARATOR);
+                    builder.append(TRACESTATE_VENDOR_SEPARATOR);
                 }
-                traceState.append(String.join(TRACESTATE_VALUE_SEPARATOR, field.getKey(), field.getValue().toString()));
+                builder.append(String.join(TRACESTATE_VALUE_SEPARATOR, field.getKey(), field.getValue().toString()));
                 first[0] = false;
             });
 
+        final String traceState = HONEYCOMB_VENDOR_PREFIX + Base64.getEncoder().encodeToString(builder.toString().getBytes(UTF_8));
         final Map<String, String> headers = new HashMap<>();
         headers.put(W3C_TRACEPARENT_HEADER, traceParent);
-        headers.put(W3C_TRACESTATE_HEADER, HONEYCOMB_VENDOR_PREFIX + Base64.getEncoder().encodeToString(traceState.toString().getBytes(UTF_8)));
+        headers.put(W3C_TRACESTATE_HEADER, traceState);
         return Optional.of(headers);
     }
 }

--- a/beeline-core/src/main/java/io/honeycomb/beeline/tracing/propagation/W3CPropagationCodec.java
+++ b/beeline-core/src/main/java/io/honeycomb/beeline/tracing/propagation/W3CPropagationCodec.java
@@ -1,6 +1,7 @@
 package io.honeycomb.beeline.tracing.propagation;
 
 import java.util.Base64;
+import java.util.Collections;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.Optional;
@@ -182,7 +183,7 @@ public class W3CPropagationCodec implements PropagationCodec<Map<String, String>
         // If no dataset or tracefields, just return trace parent header
         if (context.getDataset() == null && context.getTraceFields().isEmpty()) {
             return Optional.of(
-                Map.of(W3C_TRACEPARENT_HEADER, traceParent)
+                Collections.singletonMap(W3C_TRACEPARENT_HEADER, traceParent)
             );
         }
 
@@ -206,12 +207,9 @@ public class W3CPropagationCodec implements PropagationCodec<Map<String, String>
                 first[0] = false;
             });
 
-        // Return both traceparent and tracestate headers
-        return Optional.of(
-            Map.of(
-                W3C_TRACEPARENT_HEADER, traceParent,
-                W3C_TRACESTATE_HEADER, HONEYCOMB_VENDOR_PREFIX + Base64.getEncoder().encodeToString(traceState.toString().getBytes(UTF_8))
-            )
-        );
+        final Map<String, String> headers = new HashMap<>();
+        headers.put(W3C_TRACEPARENT_HEADER, traceParent);
+        headers.put(W3C_TRACESTATE_HEADER, HONEYCOMB_VENDOR_PREFIX + Base64.getEncoder().encodeToString(traceState.toString().getBytes(UTF_8)));
+        return Optional.of(headers);
     }
 }

--- a/beeline-core/src/test/java/io/honeycomb/beeline/tracing/propagation/W3CPropagationCodecTest.java
+++ b/beeline-core/src/test/java/io/honeycomb/beeline/tracing/propagation/W3CPropagationCodecTest.java
@@ -111,13 +111,6 @@ public class W3CPropagationCodecTest {
         assertThat(context).isEqualTo(PropagationContext.emptyContext());
     }
 
-    // empty tracestate
-    // no hny vendor
-    // hny vendor with no dataset / fields
-    // hny vendor with dataset, no fields
-    // hny vendor with fields, no dataset
-    // multiple vendors
-
     @Test
     public void GIVEN_anEmptyTrateStateHeader_EXPECT_noDatasetOrFields() {
         final String traceParentHeader = "00-4cbc8d50f02449e887e8bc2aa8020d26-ace1ecab581fc069-01";

--- a/beeline-core/src/test/java/io/honeycomb/beeline/tracing/propagation/W3CPropagationCodecTest.java
+++ b/beeline-core/src/test/java/io/honeycomb/beeline/tracing/propagation/W3CPropagationCodecTest.java
@@ -6,6 +6,7 @@ import org.junit.Test;
 import static org.assertj.core.api.Assertions.assertThat;
 
 import java.util.Collections;
+import java.util.HashMap;
 import java.util.Map;
 import java.util.Optional;
 
@@ -116,8 +117,11 @@ public class W3CPropagationCodecTest {
         final String traceParentHeader = "00-4cbc8d50f02449e887e8bc2aa8020d26-ace1ecab581fc069-01";
         final String traceStateHeader = "";
 
-        final PropagationContext context = codec.decode(Map.of(W3CPropagationCodec.W3C_TRACEPARENT_HEADER, traceParentHeader, W3CPropagationCodec.W3C_TRACESTATE_HEADER, traceStateHeader));
+        final Map<String, String> headers = new HashMap<>();
+        headers.put(W3CPropagationCodec.W3C_TRACEPARENT_HEADER, traceParentHeader);
+        headers.put(W3CPropagationCodec.W3C_TRACESTATE_HEADER, traceStateHeader);
 
+        final PropagationContext context = codec.decode(headers);
         assertThat(context.getTraceId()).isEqualTo("4cbc8d50f02449e887e8bc2aa8020d26");
         assertThat(context.getSpanId()).isEqualTo("ace1ecab581fc069");
         assertThat(context.getTraceFields().size()).isEqualTo(0);
@@ -129,8 +133,11 @@ public class W3CPropagationCodecTest {
         final String traceParentHeader = "00-4cbc8d50f02449e887e8bc2aa8020d26-ace1ecab581fc069-01";
         final String traceStateHeader = "vendor=123";
 
-        final PropagationContext context = codec.decode(Map.of(W3CPropagationCodec.W3C_TRACEPARENT_HEADER, traceParentHeader, W3CPropagationCodec.W3C_TRACESTATE_HEADER, traceStateHeader));
+        final Map<String, String> headers = new HashMap<>();
+        headers.put(W3CPropagationCodec.W3C_TRACEPARENT_HEADER, traceParentHeader);
+        headers.put(W3CPropagationCodec.W3C_TRACESTATE_HEADER, traceStateHeader);
 
+        final PropagationContext context = codec.decode(headers);
         assertThat(context.getTraceId()).isEqualTo("4cbc8d50f02449e887e8bc2aa8020d26");
         assertThat(context.getSpanId()).isEqualTo("ace1ecab581fc069");
         assertThat(context.getTraceFields().size()).isEqualTo(0);
@@ -142,8 +149,11 @@ public class W3CPropagationCodecTest {
         final String traceParentHeader = "00-4cbc8d50f02449e887e8bc2aa8020d26-ace1ecab581fc069-01";
         final String traceStateHeader = "hny=";
 
-        final PropagationContext context = codec.decode(Map.of(W3CPropagationCodec.W3C_TRACEPARENT_HEADER, traceParentHeader, W3CPropagationCodec.W3C_TRACESTATE_HEADER, traceStateHeader));
+        final Map<String, String> headers = new HashMap<>();
+        headers.put(W3CPropagationCodec.W3C_TRACEPARENT_HEADER, traceParentHeader);
+        headers.put(W3CPropagationCodec.W3C_TRACESTATE_HEADER, traceStateHeader);
 
+        final PropagationContext context = codec.decode(headers);
         assertThat(context.getTraceId()).isEqualTo("4cbc8d50f02449e887e8bc2aa8020d26");
         assertThat(context.getSpanId()).isEqualTo("ace1ecab581fc069");
         assertThat(context.getTraceFields().size()).isEqualTo(0);
@@ -155,8 +165,11 @@ public class W3CPropagationCodecTest {
         final String traceParentHeader = "00-4cbc8d50f02449e887e8bc2aa8020d26-ace1ecab581fc069-01";
         final String traceStateHeader = "hny=ZGF0YXNldD10ZXN0LWRhdGFzZXQ";
 
-        final PropagationContext context = codec.decode(Map.of(W3CPropagationCodec.W3C_TRACEPARENT_HEADER, traceParentHeader, W3CPropagationCodec.W3C_TRACESTATE_HEADER, traceStateHeader));
+        final Map<String, String> headers = new HashMap<>();
+        headers.put(W3CPropagationCodec.W3C_TRACEPARENT_HEADER, traceParentHeader);
+        headers.put(W3CPropagationCodec.W3C_TRACESTATE_HEADER, traceStateHeader);
 
+        final PropagationContext context = codec.decode(headers);
         assertThat(context.getTraceId()).isEqualTo("4cbc8d50f02449e887e8bc2aa8020d26");
         assertThat(context.getSpanId()).isEqualTo("ace1ecab581fc069");
         assertThat(context.getTraceFields().size()).isEqualTo(0);
@@ -168,8 +181,11 @@ public class W3CPropagationCodecTest {
         final String traceParentHeader = "00-4cbc8d50f02449e887e8bc2aa8020d26-ace1ecab581fc069-01";
         final String traceStateHeader = "hny=Zm9vPWJhcg==";
 
-        final PropagationContext context = codec.decode(Map.of(W3CPropagationCodec.W3C_TRACEPARENT_HEADER, traceParentHeader, W3CPropagationCodec.W3C_TRACESTATE_HEADER, traceStateHeader));
+        final Map<String, String> headers = new HashMap<>();
+        headers.put(W3CPropagationCodec.W3C_TRACEPARENT_HEADER, traceParentHeader);
+        headers.put(W3CPropagationCodec.W3C_TRACESTATE_HEADER, traceStateHeader);
 
+        final PropagationContext context = codec.decode(headers);
         assertThat(context.getTraceId()).isEqualTo("4cbc8d50f02449e887e8bc2aa8020d26");
         assertThat(context.getSpanId()).isEqualTo("ace1ecab581fc069");
         assertThat(context.getTraceFields().size()).isEqualTo(1);
@@ -182,8 +198,11 @@ public class W3CPropagationCodecTest {
         final String traceParentHeader = "00-4cbc8d50f02449e887e8bc2aa8020d26-ace1ecab581fc069-01";
         final String traceStateHeader = "hny=Zm9vPWJhcixkYXRhc2V0PXRlc3QtZGF0YXNldA==";
 
-        final PropagationContext context = codec.decode(Map.of(W3CPropagationCodec.W3C_TRACEPARENT_HEADER, traceParentHeader, W3CPropagationCodec.W3C_TRACESTATE_HEADER, traceStateHeader));
+        final Map<String, String> headers = new HashMap<>();
+        headers.put(W3CPropagationCodec.W3C_TRACEPARENT_HEADER, traceParentHeader);
+        headers.put(W3CPropagationCodec.W3C_TRACESTATE_HEADER, traceStateHeader);
 
+        final PropagationContext context = codec.decode(headers);
         assertThat(context.getTraceId()).isEqualTo("4cbc8d50f02449e887e8bc2aa8020d26");
         assertThat(context.getSpanId()).isEqualTo("ace1ecab581fc069");
         assertThat(context.getTraceFields().size()).isEqualTo(1);
@@ -196,8 +215,11 @@ public class W3CPropagationCodecTest {
         final String traceParentHeader = "00-4cbc8d50f02449e887e8bc2aa8020d26-ace1ecab581fc069-01";
         final String traceStateHeader = "vendor1=123,hny=Zm9vPWJhcixkYXRhc2V0PXRlc3QtZGF0YXNldA==,vendor2=abc";
 
-        final PropagationContext context = codec.decode(Map.of(W3CPropagationCodec.W3C_TRACEPARENT_HEADER, traceParentHeader, W3CPropagationCodec.W3C_TRACESTATE_HEADER, traceStateHeader));
+        final Map<String, String> headers = new HashMap<>();
+        headers.put(W3CPropagationCodec.W3C_TRACEPARENT_HEADER, traceParentHeader);
+        headers.put(W3CPropagationCodec.W3C_TRACESTATE_HEADER, traceStateHeader);
 
+        final PropagationContext context = codec.decode(headers);
         assertThat(context.getTraceId()).isEqualTo("4cbc8d50f02449e887e8bc2aa8020d26");
         assertThat(context.getSpanId()).isEqualTo("ace1ecab581fc069");
         assertThat(context.getTraceFields().size()).isEqualTo(1);
@@ -230,29 +252,29 @@ public class W3CPropagationCodecTest {
         String traceId = "4cbc8d50f02449e887e8bc2aa8020d26";
         String spanId = "ace1ecab581fc069";
         String dataset = "test-dataset";
-        final Map<String, String> encoded = codec.encode(new PropagationContext(traceId, spanId, dataset, null)).get();
 
-        assertThat(encoded).isEqualTo(
-            Map.of(
-                W3CPropagationCodec.W3C_TRACEPARENT_HEADER, String.join("-", "00", traceId, spanId, "00"),
-                W3CPropagationCodec.W3C_TRACESTATE_HEADER, "hny=ZGF0YXNldD10ZXN0LWRhdGFzZXQ="
-            )
-        );
+        final Map<String, String> headers = new HashMap<>();
+        headers.put(W3CPropagationCodec.W3C_TRACEPARENT_HEADER, String.join("-", "00", traceId, spanId, "00"));
+        headers.put(W3CPropagationCodec.W3C_TRACESTATE_HEADER, "hny=ZGF0YXNldD10ZXN0LWRhdGFzZXQ=");
+
+        final Map<String, String> encoded = codec.encode(new PropagationContext(traceId, spanId, dataset, null)).get();
+        assertThat(headers).isEqualTo(encoded);
     }
 
     @Test
     public void GIVEN_aPopulatedContextWithFields_EXPECT_aValidHeaderValueWithTraceState() {
         String traceId = "4cbc8d50f02449e887e8bc2aa8020d26";
         String spanId = "ace1ecab581fc069";
-        Map<String, Object> fields = Map.of("foo", "bar", "one", "two");
-        final Map<String, String> encoded = codec.encode(new PropagationContext(traceId, spanId, null, fields)).get();
+        Map<String, Object> fields = new HashMap<String, Object>();
+        fields.put("foo", "bar");
+        fields.put("one", "two");
 
-        assertThat(encoded).isEqualTo(
-            Map.of(
-                W3CPropagationCodec.W3C_TRACEPARENT_HEADER, String.join("-", "00", traceId, spanId, "00"),
-                W3CPropagationCodec.W3C_TRACESTATE_HEADER, "hny=Zm9vPWJhcixvbmU9dHdv"
-            )
-        );
+        final Map<String, String> headers = new HashMap<>();
+        headers.put(W3CPropagationCodec.W3C_TRACEPARENT_HEADER, String.join("-", "00", traceId, spanId, "00"));
+        headers.put(W3CPropagationCodec.W3C_TRACESTATE_HEADER, "hny=Zm9vPWJhcixvbmU9dHdv");
+
+        final Map<String, String> encoded = codec.encode(new PropagationContext(traceId, spanId, null, fields)).get();
+        assertThat(headers).isEqualTo(encoded);
     }
 
     @Test
@@ -260,14 +282,15 @@ public class W3CPropagationCodecTest {
         String traceId = "4cbc8d50f02449e887e8bc2aa8020d26";
         String spanId = "ace1ecab581fc069";
         String dataset = "test-dataset";
-        Map<String, Object> fields = Map.of("foo", "bar", "one", "two");
-        final Map<String, String> encoded = codec.encode(new PropagationContext(traceId, spanId, dataset, fields)).get();
+        Map<String, Object> fields = new HashMap<String, Object>();
+        fields.put("foo", "bar");
+        fields.put("one", "two");
 
-        assertThat(encoded).isEqualTo(
-            Map.of(
-                W3CPropagationCodec.W3C_TRACEPARENT_HEADER, String.join("-", "00", traceId, spanId, "00"),
-                W3CPropagationCodec.W3C_TRACESTATE_HEADER, "hny=ZGF0YXNldD10ZXN0LWRhdGFzZXQsZm9vPWJhcixvbmU9dHdv"
-            )
-        );
+        final Map<String, String> headers = new HashMap<>();
+        headers.put(W3CPropagationCodec.W3C_TRACEPARENT_HEADER, String.join("-", "00", traceId, spanId, "00"));
+        headers.put(W3CPropagationCodec.W3C_TRACESTATE_HEADER,  "hny=ZGF0YXNldD10ZXN0LWRhdGFzZXQsZm9vPWJhcixvbmU9dHdv");
+
+        final Map<String, String> encoded = codec.encode(new PropagationContext(traceId, spanId, dataset, fields)).get();
+        assertThat(headers).isEqualTo(encoded);
     }
 }


### PR DESCRIPTION
Adds support for encoding & decoding dataset and other trace fields in W3C's `tracestate` header.

NOTE: It does not limit the vendor opaque value to 256 characters as per the W3C spec.