### PR TITLE
Prepare v1.4.0 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Beeline Changelog
 
+## 1.4.0
+
+- Update CircleCI to publish to maven when creating tag (#74)
+- Add support for configuring a proxy via spring boot AutoConf settings (#77)
+
 ## 1.3.0
 
 - Tidy up pom files (#73)

--- a/beeline-core/pom.xml
+++ b/beeline-core/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>io.honeycomb.beeline</groupId>
         <artifactId>beeline-parent</artifactId>
-        <version>1.3.0</version>
+        <version>1.4.0</version>
     </parent>
 
     <name>Beeline Java (Core)</name>

--- a/beeline-core/src/test/java/io/honeycomb/beeline/builder/BeelineBuilderTest.java
+++ b/beeline-core/src/test/java/io/honeycomb/beeline/builder/BeelineBuilderTest.java
@@ -16,7 +16,6 @@ import javax.net.ssl.SSLContext;
 import java.net.URI;
 import java.net.URISyntaxException;
 
-import static org.junit.Assert.fail;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.ArgumentMatchers.eq;
@@ -71,6 +70,7 @@ public class BeelineBuilderTest {
     public void apiHost() throws URISyntaxException {
         final Beeline beeline = builder.apiHost("host:80").build();
         verify(mockBuilder, times(1)).apiHost("host:80");
+        verify(mockBuilder, times(1)).apiHost(any(URI.class));
         completeNegativeVerification();
     }
 
@@ -233,11 +233,6 @@ public class BeelineBuilderTest {
 
     private void completeNegativeVerification(){
         verify(mockBuilder, times(1)).build();
-        try {
-            verify(mockBuilder, times(1)).apiHost(any(URI.class));
-        } catch (URISyntaxException e) {
-            fail(e.toString());
-        }
         verifyNoMoreInteractions(mockBuilder);
     }
 }

--- a/beeline-core/src/test/java/io/honeycomb/beeline/builder/BeelineBuilderTest.java
+++ b/beeline-core/src/test/java/io/honeycomb/beeline/builder/BeelineBuilderTest.java
@@ -13,8 +13,10 @@ import org.mockito.junit.MockitoJUnitRunner;
 
 import javax.net.ssl.SSLContext;
 
+import java.net.URI;
 import java.net.URISyntaxException;
 
+import static org.junit.Assert.fail;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.ArgumentMatchers.eq;
@@ -231,6 +233,11 @@ public class BeelineBuilderTest {
 
     private void completeNegativeVerification(){
         verify(mockBuilder, times(1)).build();
+        try {
+            verify(mockBuilder, times(1)).apiHost(any(URI.class));
+        } catch (URISyntaxException e) {
+            fail(e.toString());
+        }
         verifyNoMoreInteractions(mockBuilder);
     }
 }

--- a/beeline-spring-boot-sleuth-starter/pom.xml
+++ b/beeline-spring-boot-sleuth-starter/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>io.honeycomb.beeline</groupId>
         <artifactId>beeline-parent</artifactId>
-        <version>1.3.0</version>
+        <version>1.4.0</version>
     </parent>
 
     <name>Beeline Java (Spring Boot Sleuth Starter)</name>

--- a/beeline-spring-boot-starter/pom.xml
+++ b/beeline-spring-boot-starter/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>io.honeycomb.beeline</groupId>
         <artifactId>beeline-parent</artifactId>
-        <version>1.3.0</version>
+        <version>1.4.0</version>
     </parent>
 
     <name>Beeline Java (Spring Boot Starter)</name>

--- a/beeline-spring-boot-starter/src/main/java/io/honeycomb/beeline/spring/autoconfig/BeelineAutoconfig.java
+++ b/beeline-spring-boot-starter/src/main/java/io/honeycomb/beeline/spring/autoconfig/BeelineAutoconfig.java
@@ -99,12 +99,7 @@ public class BeelineAutoconfig implements WebMvcConfigurer {
 
         // set apiHost if not empty
         if (beelineProperties.getApiHost() != null) {
-            // TODO: allow raw URI to be passed into LibHoneyBuilder to avoid re-parsing URI
-            try {
-                builder.apiHost(beelineProperties.getApiHost().toString());
-            } catch (URISyntaxException e) {
-                // eat error for now
-            }
+            builder.apiHost(beelineProperties.getApiHost());
         }
 
         // map static and dynamic fields

--- a/beeline-spring-boot-starter/src/main/java/io/honeycomb/beeline/spring/autoconfig/BeelineAutoconfig.java
+++ b/beeline-spring-boot-starter/src/main/java/io/honeycomb/beeline/spring/autoconfig/BeelineAutoconfig.java
@@ -99,7 +99,12 @@ public class BeelineAutoconfig implements WebMvcConfigurer {
 
         // set apiHost if not empty
         if (beelineProperties.getApiHost() != null) {
-            builder.apiHost(beelineProperties.getApiHost());
+            // TODO: allow raw URI to be passed into LibHoneyBuilder to avoid re-parsing URI
+            try {
+                builder.apiHost(beelineProperties.getApiHost().toString());
+            } catch (URISyntaxException e) {
+                // eat error for now
+            }
         }
 
         // map static and dynamic fields

--- a/pom.xml
+++ b/pom.xml
@@ -7,7 +7,7 @@
     <name>Beeline Java (Parent)</name>
     <artifactId>beeline-parent</artifactId>
     <groupId>io.honeycomb.beeline</groupId>
-    <version>1.3.0</version>
+    <version>1.4.0</version>
     <packaging>pom</packaging>
 
     <description>Parent POM for the Honeycomb Beeline for Java</description>
@@ -71,7 +71,7 @@
         <jdkVersion>1.8</jdkVersion>
 
         <!-- COMPILE dependency versions  -->
-        <libhoneyVersion>1.1.2</libhoneyVersion>
+        <libhoneyVersion>1.3.0</libhoneyVersion>
         <springBootVersion>2.1.1.RELEASE</springBootVersion>
 
         <!-- TEST dependency versions  -->


### PR DESCRIPTION
Prepares the next release of the Beeline, including Spring Boot and Slueth.

Included changes:
- update beeline version to 1.4.0
- update libhoney dependency to 1.3.0
- fixes a negative verification test as part of the libhoney update in BeelineBuilderTest

NOTE: Depends on pending [libhoney 1.3.0](https://github.com/honeycombio/libhoney-java/pull/36) release.