### PR TITLE
Use HoneyClientBuilder.apiHost URI overload 

### DIFF
--- a/beeline-spring-boot-sleuth-starter/pom.xml
+++ b/beeline-spring-boot-sleuth-starter/pom.xml
@@ -16,7 +16,7 @@
     <description>Spring Boot Sleuth Starter module to auto-configure Spring Boot Sleuth to send trace data via Honeycomb Beeline for Java</description>
 
     <properties>
-        <beelineVersion>1.3.0</beelineVersion>
+        <beelineVersion>1.4.0</beelineVersion>
     </properties>
 
     <build>

--- a/beeline-spring-boot-starter/pom.xml
+++ b/beeline-spring-boot-starter/pom.xml
@@ -16,7 +16,7 @@
     <description>Spring Boot Starter module to auto-configure Spring Boot with the Honeycomb Beeline for Java</description>
 
     <properties>
-        <beelineVersion>1.3.0</beelineVersion>
+        <beelineVersion>1.4.0</beelineVersion>
     </properties>
 
     <build>

--- a/beeline-spring-boot-starter/src/main/java/io/honeycomb/beeline/spring/autoconfig/BeelineAutoconfig.java
+++ b/beeline-spring-boot-starter/src/main/java/io/honeycomb/beeline/spring/autoconfig/BeelineAutoconfig.java
@@ -37,6 +37,7 @@ import org.springframework.web.servlet.config.annotation.WebMvcConfigurer;
 
 import javax.servlet.DispatcherType;
 
+import java.net.URI;
 import java.net.URISyntaxException;
 import java.util.List;
 import java.util.Map;
@@ -99,9 +100,8 @@ public class BeelineAutoconfig implements WebMvcConfigurer {
 
         // set apiHost if not empty
         if (beelineProperties.getApiHost() != null) {
-            // TODO: allow raw URI to be passed into LibHoneyBuilder to avoid re-parsing URI
             try {
-                builder.apiHost(beelineProperties.getApiHost().toString());
+                builder.apiHost(beelineProperties.getApiHost());
             } catch (URISyntaxException e) {
                 // eat error for now
             }


### PR DESCRIPTION
Libhoney's HoneyClientBuilder was extended to offer an overload of apiHost that takes a pre-built URI. This is useful because we already have a pre-built URI as part of the autoconf beelineproperties and means we don't have to cast back to a string.

NOTE: This change includes updating both the spring boot and sleuth projects to use the latest beeline 1.4.0 version.