### PR TITLE
Allow span duration to be set directly

### DIFF
--- a/beeline-core/src/main/java/io/honeycomb/beeline/tracing/Span.java
+++ b/beeline-core/src/main/java/io/honeycomb/beeline/tracing/Span.java
@@ -88,6 +88,7 @@ public class Span implements AutoCloseable {
     private static final long ABSENT_TIME = -1L;
     private long startTimestamp = ABSENT_TIME;
     private long startOfElapsedTime = ABSENT_TIME;
+    private double durationMs = ABSENT_TIME;
 
     /**
      * Flag to indicate whether close has already been called.
@@ -252,6 +253,20 @@ public class Span implements AutoCloseable {
         return this;
     }
 
+    /**
+     * Sets the duration using a double with sub-millis in the fractional part. This overrides the default
+     * behaviour of calculating the elasped duration using the start time (monotonic JVM time).
+     *
+     * @param duration in milliseconds.
+     * @return this Span.
+     */
+    public Span setDuration(final double duration) {
+        if (isNoop()) return this;
+
+        this.durationMs = duration;
+        return this;
+    }
+
     public String getParentSpanId() {
         return parentSpanId;
     }
@@ -306,11 +321,19 @@ public class Span implements AutoCloseable {
     }
 
     /**
-     * @return the time elapsed since "markStart" as a double with sub-millis in the fractional part.
+     * @return the time elapsed since "markStart" as a double with sub-millis in the fractional part and is
+     * calcualted using the start time (monotonic JVM time).
+     * <p>
+     * This can be overwritten by called "setDuration" and will be used in place of calculating the value.
      * @see #markStart()
+     * @see #setDuration(long)
      */
     public double elapsedTimeMs() {
         if (isNoop()) return 0.0;
+
+        if (durationMs != ABSENT_TIME) {
+            return durationMs;
+        }
 
         return (double) (clock.getMonotonicTime() - startOfElapsedTime) / NANOS_TO_MILLIS_DIVISOR;
     }

--- a/beeline-core/src/main/java/io/honeycomb/beeline/tracing/TracerSpan.java
+++ b/beeline-core/src/main/java/io/honeycomb/beeline/tracing/TracerSpan.java
@@ -79,6 +79,11 @@ public class TracerSpan extends Span {
     }
 
     @Override
+    public Span setDuration(final double duration) {
+        return delegate.setDuration(duration);
+    }
+
+    @Override
     public String getParentSpanId() {
         return delegate.getParentSpanId();
     }

--- a/beeline-spring-boot-sleuth-starter/src/main/java/io/honeycomb/beeline/spring/beans/BraveBeelineReporter.java
+++ b/beeline-spring-boot-sleuth-starter/src/main/java/io/honeycomb/beeline/spring/beans/BraveBeelineReporter.java
@@ -23,6 +23,8 @@ import zipkin2.reporter.Reporter;
  */
 public class BraveBeelineReporter implements Reporter<Span> {
 
+    private static final Short MICROS_IN_MILLISECOND = 1000;
+
     private final Beeline beeline;
     private final BeelineProperties properties;
 
@@ -68,7 +70,7 @@ public class BraveBeelineReporter implements Reporter<Span> {
         }
         if (span.durationAsLong() > 0) {
             // Brave uses zero for no timestamp
-            hcRootSpan.setDuration((double) span.durationAsLong() / 1000);
+            hcRootSpan.setDuration((double) span.durationAsLong() / MICROS_IN_MILLISECOND);
         }
         return hcRootSpan;
     }

--- a/beeline-spring-boot-sleuth-starter/src/main/java/io/honeycomb/beeline/spring/beans/BraveBeelineReporter.java
+++ b/beeline-spring-boot-sleuth-starter/src/main/java/io/honeycomb/beeline/spring/beans/BraveBeelineReporter.java
@@ -40,11 +40,6 @@ public class BraveBeelineReporter implements Reporter<Span> {
     }
 
     private void adaptBraveModelToHoneycombModel(final Span span, final io.honeycomb.beeline.tracing.Span hcRootSpan) {
-        final long startTime = span.timestampAsLong();
-        if (startTime > 0) {
-            // Brave uses 0 for no timestamp while Honeycomb uses -1L
-            hcRootSpan.markStart(startTime, startTime);
-        }
         adaptBraveAnnotationToHoneycombSpanEvent(span, hcRootSpan);
         ExtraFieldPropagation.getAll().forEach(hcRootSpan::addField);
         span.tags().forEach(hcRootSpan::addField);

--- a/beeline-spring-boot-sleuth-starter/src/main/java/io/honeycomb/beeline/spring/beans/BraveBeelineReporter.java
+++ b/beeline-spring-boot-sleuth-starter/src/main/java/io/honeycomb/beeline/spring/beans/BraveBeelineReporter.java
@@ -68,7 +68,7 @@ public class BraveBeelineReporter implements Reporter<Span> {
         }
         if (span.durationAsLong() > 0) {
             // Brave uses zero for no timestamp
-            hcRootSpan.setDuration(span.durationAsLong());
+            hcRootSpan.setDuration((double) span.durationAsLong() / 1000);
         }
         return hcRootSpan;
     }

--- a/beeline-spring-boot-sleuth-starter/src/main/java/io/honeycomb/beeline/spring/beans/BraveBeelineReporter.java
+++ b/beeline-spring-boot-sleuth-starter/src/main/java/io/honeycomb/beeline/spring/beans/BraveBeelineReporter.java
@@ -7,10 +7,7 @@ import io.honeycomb.beeline.spring.autoconfig.BeelineProperties;
 import io.honeycomb.beeline.tracing.Beeline;
 import io.honeycomb.beeline.tracing.SpanBuilderFactory;
 import io.honeycomb.beeline.tracing.propagation.PropagationContext;
-import io.honeycomb.beeline.tracing.utils.TraceFieldConstants;
 import io.honeycomb.libhoney.Event;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 import zipkin2.Span;
 import zipkin2.reporter.Reporter;
 

--- a/beeline-spring-boot-sleuth-starter/src/main/java/io/honeycomb/beeline/spring/beans/BraveBeelineReporter.java
+++ b/beeline-spring-boot-sleuth-starter/src/main/java/io/honeycomb/beeline/spring/beans/BraveBeelineReporter.java
@@ -73,7 +73,7 @@ public class BraveBeelineReporter implements Reporter<Span> {
         }
         if (span.durationAsLong() > 0) {
             // Brave uses zero for no timestamp
-            hcRootSpan.addField(TraceFieldConstants.DURATION_FIELD, span.durationAsLong());
+            hcRootSpan.setDuration(span.durationAsLong());
         }
         return hcRootSpan;
     }

--- a/beeline-spring-boot-sleuth-starter/src/test/java/io/honeycomb/beeline/spring/beans/BraveBeelineReporterTest.java
+++ b/beeline-spring-boot-sleuth-starter/src/test/java/io/honeycomb/beeline/spring/beans/BraveBeelineReporterTest.java
@@ -130,7 +130,7 @@ public class BraveBeelineReporterTest {
 
     @Test
     public void GIVEN_spanWithDuration_EXPECT_eventWithDuration() {
-        final Span span = spanBuilder.duration(10760L).build(); // 10.76 millis in micros
+        final Span span = spanBuilder.duration(494L).build(); // 0.494 millis in micros
         reporter.report(span);
         verify(mockTransport, times(1)).submit((ResolvedEvent) captor.capture());
         final Object captured = captor.getValue();
@@ -138,7 +138,7 @@ public class BraveBeelineReporterTest {
         final ResolvedEvent event = (ResolvedEvent) captured;
         final Map<String, Object> actualFields = event.getFields();
         Assert.assertTrue("Expected duration on event", actualFields.containsKey(TraceFieldConstants.DURATION_FIELD));
-        Assert.assertEquals("10.76", String.valueOf(actualFields.get(TraceFieldConstants.DURATION_FIELD)));
+        Assert.assertEquals("0.494", String.valueOf(actualFields.get(TraceFieldConstants.DURATION_FIELD)));
     }
 
     @Test

--- a/beeline-spring-boot-sleuth-starter/src/test/java/io/honeycomb/beeline/spring/beans/BraveBeelineReporterTest.java
+++ b/beeline-spring-boot-sleuth-starter/src/test/java/io/honeycomb/beeline/spring/beans/BraveBeelineReporterTest.java
@@ -130,7 +130,7 @@ public class BraveBeelineReporterTest {
 
     @Test
     public void GIVEN_spanWithDuration_EXPECT_eventWithDuration() {
-        final Span span = spanBuilder.duration(494L).build();
+        final Span span = spanBuilder.duration(10760L).build(); // 10.76 millis in micros
         reporter.report(span);
         verify(mockTransport, times(1)).submit((ResolvedEvent) captor.capture());
         final Object captured = captor.getValue();
@@ -138,7 +138,7 @@ public class BraveBeelineReporterTest {
         final ResolvedEvent event = (ResolvedEvent) captured;
         final Map<String, Object> actualFields = event.getFields();
         Assert.assertTrue("Expected duration on event", actualFields.containsKey(TraceFieldConstants.DURATION_FIELD));
-
+        Assert.assertEquals("10.76", String.valueOf(actualFields.get(TraceFieldConstants.DURATION_FIELD)));
     }
 
     @Test


### PR DESCRIPTION
Normally a span's elapsed duration is calculated using the JVM monotonic start time. However, when converting a span from another format (eg Zipking using the BraveBeelineReporter) that provides it's own start times, it's not possible to accurately use the monotonic clock and makes the duration widely inaccurate.

This change allows a span to explicitly set it's duration that be used in place of the traditional calculation. The default behaviour is to rely on the monotonic clock.