### PR TITLE
Change Brave span transforming to properly associate spans

### DIFF
--- a/beeline-spring-boot-sleuth-starter/src/main/java/io/honeycomb/beeline/spring/beans/BraveBeelineReporter.java
+++ b/beeline-spring-boot-sleuth-starter/src/main/java/io/honeycomb/beeline/spring/beans/BraveBeelineReporter.java
@@ -71,7 +71,7 @@ public class BraveBeelineReporter implements Reporter<Span> {
         );
         final Long startTimestamp = span.timestamp();
         if (startTimestamp != null && startTimestamp > 0) {
-            hcRootSpan.markStart(startTimestamp/1000, startTimestamp/1000);
+            hcRootSpan.markStart(startTimestamp / MICROS_IN_MILLISECOND, startTimestamp / MICROS_IN_MILLISECOND);
         }
         if (span.durationAsLong() > 0) {
             // Brave uses zero for no timestamp

--- a/beeline-spring-boot-sleuth-starter/src/main/java/io/honeycomb/beeline/spring/beans/BraveBeelineReporter.java
+++ b/beeline-spring-boot-sleuth-starter/src/main/java/io/honeycomb/beeline/spring/beans/BraveBeelineReporter.java
@@ -60,11 +60,18 @@ public class BraveBeelineReporter implements Reporter<Span> {
     }
 
     private io.honeycomb.beeline.tracing.Span transformBraveSpanToHoneycombSpan(final Span span) {
-        final PropagationContext propagationContext = new PropagationContext(span.traceId(), span.id(), null, null);
-        final io.honeycomb.beeline.tracing.Span hcRootSpan = beeline.startTrace(span.name(), propagationContext, properties.getServiceName());
-        final long startTimestamp = span.timestamp();
-        if (startTimestamp > 0) {
-            hcRootSpan.markStart(startTimestamp, startTimestamp);
+        final PropagationContext propagationContext = new PropagationContext(span.traceId(), span.parentId(), null, null);
+        final io.honeycomb.beeline.tracing.Span hcRootSpan = beeline.getTracer().startTrace(
+            beeline.getSpanBuilderFactory().createBuilder()
+                .setSpanName(span.name())
+                .setServiceName(properties.getServiceName())
+                .setParentContext(propagationContext)
+                .setSpanId(span.id())
+                .build()
+        );
+        final Long startTimestamp = span.timestamp();
+        if (startTimestamp != null && startTimestamp > 0) {
+            hcRootSpan.markStart(startTimestamp/1000, startTimestamp/1000);
         }
         if (span.durationAsLong() > 0) {
             // Brave uses zero for no timestamp


### PR DESCRIPTION
This does a few things differently:

* Makes the `propagationContext` based on the `traceId` + `parentId` (instead of `spanId`)
* Changes the `hcRootSpan` to force `spanId = $spanId` from the Brave span
* Converts the brave span timestamp to be the same format as HC (I believe this is microseconds -> milliseconds)

Without these changes, we see missing spans and the timestamps appear to be calculated by the HC server when received. With these changes, all spans are linked properly and timestamps appear to be consistent.

Please let me know if any of this does or doesn't make sense; I'm not sure if there was a reason that this transformer _didn't_ re-use the `spanId`/`parentSpanId`/`traceId` exactly from the Brave span.

Thanks!