### PR TITLE
Rework build, add matrix and use orb, fix tag filters

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -17,7 +17,7 @@ jobs:
       java-version:
         type: string
     executor:
-      name: java/default
+      name: maven/default
       tag: << parameters.java-version >>
     steps:
       - checkout

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -68,7 +68,6 @@ workflows:
               java-version:
                 - "8.0"
                 - "11.0"
-                - "15.0"
   build:
     jobs:
       - java:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -26,9 +26,6 @@ jobs:
             - run: mvn clean test
 
   package:
-    executor:
-      name: maven/default
-      tag: "11.0"
     steps:
       - checkout
       - maven/with_cache:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -3,14 +3,6 @@ version: 2.1
 orbs:
   maven: circleci/maven@1.0.3
 
-commands:
-  configure-gpg:
-    steps:
-      - run:
-          name: Configure GPG private key for signing project artifacts in OSS Sonatype
-          command: |
-            echo $GPG_BASE64 | base64 --decode | gpg --batch --no-tty --import --yes
-
 jobs:
   test:
     parameters:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -34,7 +34,8 @@ jobs:
       - maven/with_cache:
           steps:
             - run: mkdir -p ~/artifacts
-            - run: mvn clean package -Dmaven.test.skip=true -DoutputDirectory=~/artifacts
+            - run: mvn clean package -Dmaven.test.skip=true
+            - run: cp */target/*.jar ~/artifacts
             - persist_to_workspace:
                 root: ~/
                 paths:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -88,7 +88,7 @@ workflows:
       - package:
           requires:
             - test
-          filters:
+          filters: &tag_filters
             tags:
               only: /^v.*/
             branches:
@@ -97,16 +97,8 @@ workflows:
           context: Honeycomb Secrets
           requires:
             - package
-          filters:
-            tags:
-              only: /^v.*/
-            branches:
-              ignore: /.*/
+          filters: *tag_filters
       - publish_maven:
           requires:
             - test
-          filters:
-            tags:
-              only: /^v.*/
-            branches:
-              ignore: /.*/
+          filters: *tag_filters

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -18,6 +18,9 @@ jobs:
             - run: mvn clean test
 
   package:
+    executor: &default_executor
+      name: maven/default
+      tag: "11.0"
     steps:
       - checkout
       - maven/with_cache:
@@ -46,6 +49,7 @@ jobs:
             ghr -draft -n ${CIRCLE_TAG} -t ${GITHUB_TOKEN} -u ${CIRCLE_PROJECT_USERNAME} -r ${CIRCLE_PROJECT_REPONAME} -c ${CIRCLE_SHA1} ${CIRCLE_TAG} ~/artifacts
 
   publish_maven:
+    executor: *default_executor
     steps:
       - checkout
       - maven/with_cache:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -66,10 +66,10 @@ workflows:
           matrix:
             parameters:
               java-version:
-                - "8"
-                - "9"
-                - "10"
-                - "11"
+                - "8.0"
+                - "9.0"
+                - "10.0"
+                - "11.0"
   build:
     jobs:
       - java:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -80,7 +80,7 @@ workflows:
               - "11"
   build:
     jobs:
-      - java: &java
+      - java: *java
       - publish_github:
           context: Honeycomb Secrets
           filters:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -57,21 +57,15 @@ jobs:
             ghr -draft -n ${CIRCLE_TAG} -t ${GITHUB_TOKEN} -u ${CIRCLE_PROJECT_USERNAME} -r ${CIRCLE_PROJECT_REPONAME} -c ${CIRCLE_SHA1} ${CIRCLE_TAG} ~/artifacts
 
   publish_maven:
-    docker:
-      - image: circleci/openjdk:11-jdk
     steps:
-      - restore_cache:
-          key: beeline-java-{{ checksum ".circleci/config.yml" }}
-      - configure-gpg
-      - run:
-          name: "Publish to Sonatype / Maven Central"
-          command: |
-            echo "Publishing tag ${CIRCLE_TAG} to Sontatype / Maven Central"
-            ./mvnw -s .circleci/maven-release-settings.xml clean deploy -DskipTests
-      - save_cache:
-          paths:
-            - ~/.m2
-          key: beeline-java-{{ checksum ".circleci/config.yml" }}
+      - checkout
+      - maven/with_cache:
+          steps:
+            - run:
+                name: Configure GPG private key for signing project artifacts in OSS Sonatype
+                command: |
+                  echo $GPG_BASE64 | base64 --decode | gpg --batch --no-tty --import --yes
+            - run: mvn -s .circleci/maven-release-settings.xml clean deploy -Dmaven.test.skip=true
 
 workflows:
   version: 2

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -80,7 +80,11 @@ workflows:
                 - "11"
   build:
     jobs:
-      - java: *java
+      - java:
+          <<: *java
+          filters:
+            tags:
+              only: /.*/
       - publish_github:
           context: Honeycomb Secrets
           filters:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -12,7 +12,7 @@ commands:
             echo $GPG_BASE64 | base64 --decode | gpg --batch --no-tty --import --yes
 
 jobs:
-  java:
+  test:
     parameters:
       java-version:
         type: string
@@ -23,7 +23,17 @@ jobs:
       - checkout
       - maven/with_cache:
           steps:
-            - run: mvn package dependency:go-offline
+            - run: mvn clean test
+
+  package:
+    executor:
+      name: maven/default
+      tag: "11.0"
+    steps:
+      - checkout
+      - maven/with_cache:
+          steps:
+            - run: mvn clean package -Dmaven.test.skip=true
 
   publish_github:
     docker:
@@ -62,7 +72,7 @@ workflows:
               only:
                 - main
     jobs:
-      - java: &java
+      - test: &test
           matrix:
             parameters:
               java-version:
@@ -70,19 +80,29 @@ workflows:
                 - "11.0"
   build:
     jobs:
-      - java:
-          <<: *java
+      - test:
+          <<: *test
+          filters:
+            tags:
+              only: /.*/
+      - package:
+          requires:
+            - test
           filters:
             tags:
               only: /.*/
       - publish_github:
           context: Honeycomb Secrets
+          requires:
+            - package
           filters:
             tags:
               only: /^v.*/
             branches:
               ignore: /.*/
       - publish_maven:
+          requires:
+            - package
           filters:
             tags:
               only: /^v.*/

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -47,11 +47,15 @@ jobs:
     docker:
       - image: cibuilds/github:0.13.0
     steps:
+      - attach_workspace:
+          at: ~/
       - run:
           name: "Publish Release on GitHub"
           command: |
             echo "about to publish to tag ${CIRCLE_TAG}"
-            ghr -draft -n ${CIRCLE_TAG} -t ${GITHUB_TOKEN} -u ${CIRCLE_PROJECT_USERNAME} -r ${CIRCLE_PROJECT_REPONAME} -c ${CIRCLE_SHA1} ${CIRCLE_TAG}
+            ls -l ~/artifacts/*
+            ghr -draft -n ${CIRCLE_TAG} -t ${GITHUB_TOKEN} -u ${CIRCLE_PROJECT_USERNAME} -r ${CIRCLE_PROJECT_REPONAME} -c ${CIRCLE_SHA1} ${CIRCLE_TAG} ~/artifacts
+
   publish_maven:
     docker:
       - image: circleci/openjdk:11-jdk
@@ -98,7 +102,9 @@ workflows:
             - test
           filters:
             tags:
-              only: /.*/
+              only: /^v.*/
+            branches:
+              ignore: /.*/
       - publish_github:
           context: Honeycomb Secrets
           requires:
@@ -110,7 +116,7 @@ workflows:
               ignore: /.*/
       - publish_maven:
           requires:
-            - package
+            - test
           filters:
             tags:
               only: /^v.*/

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,20 +1,9 @@
 version: 2.1
 
+orbs:
+  maven: circleci/maven@1.0.3
+
 commands:
-  build:
-    parameters:
-      javaversion:
-        type: string
-        default: "8"
-    steps:
-      - checkout
-      - restore_cache:
-          key: beeline-java-{{ checksum "pom.xml" }}-<< parameters.javaversion >>
-      - run: ./mvnw package dependency:go-offline
-      - save_cache:
-          paths:
-            - ~/.m2
-          key: beeline-java-{{ checksum "pom.xml" }}-<< parameters.javaversion >>
   configure-gpg:
     steps:
       - run:
@@ -23,15 +12,19 @@ commands:
             echo $GPG_BASE64 | base64 --decode | gpg --batch --no-tty --import --yes
 
 jobs:
-  java:
+  test:
     parameters:
-      javaversion:
+      java-version:
         type: string
-        default: "8"
-    docker:
-      - image: circleci/openjdk:<< parameters.javaversion >>-jdk
+    executor:
+      name: java/default
+      tag: << parameters.java-version >>
     steps:
-      - build
+      - checkout
+      - maven/with_cache:
+          steps:
+            - run: package dependency:go-offline
+
   publish_github:
     docker:
       - image: cibuilds/github:0.13.0
@@ -73,7 +66,7 @@ workflows:
       - java: &java
           matrix:
             parameters:
-              javaversion:
+              java-version:
                 - "8"
                 - "9"
                 - "10"

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -70,32 +70,17 @@ workflows:
               only:
                 - main
     jobs:
-      - java:
-          javaversion: "8"
-          name: JDK-8
-      - java:
-          javaversion: "9"
-          name: JDK-9
-      - java:
-          javaversion: "10"
-          name: JDK-10
-      - java:
-          javaversion: "11"
-          name: JDK-11
+      java: &java
+        matrix:
+          parameters:
+            javaversion:
+              - "8"
+              - "9"
+              - "10"
+              - "11"
   build:
     jobs:
-      - java:
-          javaversion: "8"
-          name: JDK-8
-      - java:
-          javaversion: "9"
-          name: JDK-9
-      - java:
-          javaversion: "10"
-          name: JDK-10
-      - java:
-          javaversion: "11"
-          name: JDK-11
+      - java: &java
       - publish_github:
           context: Honeycomb Secrets
           filters:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -33,7 +33,14 @@ jobs:
       - checkout
       - maven/with_cache:
           steps:
-            - run: mvn clean package -Dmaven.test.skip=true
+            - run: mkdir -p ~/artifacts
+            - run: mvn clean package -Dmaven.test.skip=true -DoutputDirectory=~/artifacts
+            - persist_to_workspace:
+                root: ~/
+                paths:
+                  - artifacts
+            - store_artifacts:
+                path: ~/artifacts
 
   publish_github:
     docker:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -81,6 +81,7 @@ workflows:
               java-version:
                 - "8.0"
                 - "11.0"
+                - "13.0"
   build:
     jobs:
       - test:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -67,9 +67,8 @@ workflows:
             parameters:
               java-version:
                 - "8.0"
-                - "9.0"
-                - "10.0"
                 - "11.0"
+                - "15.0"
   build:
     jobs:
       - java:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -12,7 +12,7 @@ commands:
             echo $GPG_BASE64 | base64 --decode | gpg --batch --no-tty --import --yes
 
 jobs:
-  test:
+  java:
     parameters:
       java-version:
         type: string

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -70,14 +70,14 @@ workflows:
               only:
                 - main
     jobs:
-      java: &java
-        matrix:
-          parameters:
-            javaversion:
-              - "8"
-              - "9"
-              - "10"
-              - "11"
+      - java: &java
+          matrix:
+            parameters:
+              javaversion:
+                - "8"
+                - "9"
+                - "10"
+                - "11"
   build:
     jobs:
       - java: *java

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -29,7 +29,6 @@ jobs:
     docker:
       - image: cibuilds/github:0.13.0
     steps:
-      - build
       - run:
           name: "Publish Release on GitHub"
           command: |

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -23,7 +23,7 @@ jobs:
       - checkout
       - maven/with_cache:
           steps:
-            - run: package dependency:go-offline
+            - run: mvn package dependency:go-offline
 
   publish_github:
     docker:


### PR DESCRIPTION
- Move to use the maven orb provided by circle ci
- Use build matrix to simplify the config file
- Add the appropriate filters to the publish jobs so that they run when a build is tagged

If this looks good it should be easily able to be ported over to https://github.com/honeycombio/libhoney-java