### PR TITLE
Use new context for maven creds

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -99,6 +99,7 @@ workflows:
             - package
           filters: *tag_filters
       - publish_maven:
+          context: java_beeline
           requires:
             - test
           filters: *tag_filters


### PR DESCRIPTION
Created as part of https://github.com/honeycombio/libhoney-java/pull/41 so that we can share the maven creds between the repos