### PR TITLE
Fix CircleCI test failures

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -13,9 +13,14 @@ jobs:
       tag: << parameters.java-version >>
     steps:
       - checkout
-      - maven/with_cache:
-          steps:
-            - run: mvn clean test
+      - run: find . -name 'pom.xml' | sort | xargs cat > /tmp/maven_cache_seed
+      - restore_cache:
+          key: maven-{{ checksum "/tmp/maven_cache_seed" }}
+      - run: mvn clean test dependency:go-offline
+      - save_cache:
+          paths:
+            - ~/.m2/repository
+          key: maven-{{ checksum "/tmp/maven_cache_seed" }}
 
   package:
     executor: &default_executor
@@ -23,17 +28,22 @@ jobs:
       tag: "11.0"
     steps:
       - checkout
-      - maven/with_cache:
-          steps:
-            - run: mkdir -p ~/artifacts
-            - run: mvn clean package -Dmaven.test.skip=true
-            - run: cp */target/*.jar ~/artifacts
-            - persist_to_workspace:
-                root: ~/
-                paths:
-                  - artifacts
-            - store_artifacts:
-                path: ~/artifacts
+      - run: find . -name 'pom.xml' | sort | xargs cat > /tmp/maven_cache_seed
+      - restore_cache:
+          key: maven-{{ checksum "/tmp/maven_cache_seed" }}
+      - run: mkdir -p ~/artifacts
+      - run: mvn clean package -Dmaven.test.skip=true
+      - run: cp */target/*.jar ~/artifacts
+      - persist_to_workspace:
+          root: ~/
+          paths:
+            - artifacts
+      - store_artifacts:
+          path: ~/artifacts
+      - save_cache:
+          paths:
+            - ~/.m2/repository
+          key: maven-{{ checksum "/tmp/maven_cache_seed" }}
 
   publish_github:
     docker:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -3,6 +3,21 @@ version: 2.1
 orbs:
   maven: circleci/maven@1.0.3
 
+commands:
+  with_cache:
+    parameters:
+      steps:
+        type: steps
+    steps:
+      - run: find . -name 'pom.xml' | sort | xargs cat > /tmp/maven_cache_seed
+      - restore_cache:
+          key: maven-{{ checksum "/tmp/maven_cache_seed" }}
+      - steps: << parameters.steps >>
+      - save_cache:
+          paths:
+            - ~/.m2/repository
+          key: maven-{{ checksum "/tmp/maven_cache_seed" }}
+
 jobs:
   test:
     parameters:
@@ -13,14 +28,9 @@ jobs:
       tag: << parameters.java-version >>
     steps:
       - checkout
-      - run: find . -name 'pom.xml' | sort | xargs cat > /tmp/maven_cache_seed
-      - restore_cache:
-          key: maven-{{ checksum "/tmp/maven_cache_seed" }}
-      - run: mvn clean test dependency:go-offline
-      - save_cache:
-          paths:
-            - ~/.m2/repository
-          key: maven-{{ checksum "/tmp/maven_cache_seed" }}
+      - with_cache:
+          steps:
+            - run: mvn verify dependency:go-offline
 
   package:
     executor: &default_executor
@@ -28,22 +38,17 @@ jobs:
       tag: "11.0"
     steps:
       - checkout
-      - run: find . -name 'pom.xml' | sort | xargs cat > /tmp/maven_cache_seed
-      - restore_cache:
-          key: maven-{{ checksum "/tmp/maven_cache_seed" }}
-      - run: mkdir -p ~/artifacts
-      - run: mvn clean package -Dmaven.test.skip=true
-      - run: cp */target/*.jar ~/artifacts
-      - persist_to_workspace:
-          root: ~/
-          paths:
-            - artifacts
-      - store_artifacts:
-          path: ~/artifacts
-      - save_cache:
-          paths:
-            - ~/.m2/repository
-          key: maven-{{ checksum "/tmp/maven_cache_seed" }}
+      - with_cache:
+          steps:
+            - run: mkdir -p ~/artifacts
+            - run: mvn clean package -Dmaven.test.skip=true
+            - run: cp */target/*.jar ~/artifacts
+            - persist_to_workspace:
+                root: ~/
+                paths:
+                  - artifacts
+            - store_artifacts:
+                path: ~/artifacts
 
   publish_github:
     docker:

--- a/beeline-core/src/main/java/io/honeycomb/beeline/DefaultBeeline.java
+++ b/beeline-core/src/main/java/io/honeycomb/beeline/DefaultBeeline.java
@@ -107,7 +107,7 @@ public class DefaultBeeline {
      * This is to avoid clashes and distinguish it from standard fields provided by automatic instrumentations like
      * the "Spring Beeline".
      *
-     * <h1>Example</h1>
+     * <b>Example</b>
      * <pre>
      * if (underAttack) {
      *      beeline.addField("alert-message", "We are under attack!");
@@ -128,7 +128,7 @@ public class DefaultBeeline {
      * Note, this method is null-safe - a "noop" span is returned if no trace is currently active. This may be due to
      * the current execution not being instrumented or because the trace was not sampled.
      *
-     * <h1>Example</h1>
+     * <p>Example</p>
      * <pre>
      * if (underAttack) {
      *      final Span currentSpan = beeline.getActiveSpan()

--- a/beeline-core/src/main/java/io/honeycomb/beeline/tracing/Beeline.java
+++ b/beeline-core/src/main/java/io/honeycomb/beeline/tracing/Beeline.java
@@ -18,7 +18,7 @@ import java.util.ArrayList;
  * closing the span} pops it back off. <em>Take care to always close the Spans you create</em> to ensure correct
  * measurements of duration and timely submission to Honeycomb.
  *
- * <h1>Instrumentation</h1>
+ * <p>Instrumentation</p>
  * When using this class, it is assumed that your framework instrumentation would have initialized an initial "root"
  * Span, alleviating the burden of having to manage low-level details.
  * For example, the <b>Spring Beeline</b> creates a "root" span for all incoming HTTP requests and closes it when the
@@ -28,7 +28,7 @@ import java.util.ArrayList;
  * {@link #getSpanBuilderFactory()}. The Beeline class is essentially a façade to those delegates,
  * narrowing and bundling lower-level APIs to target the most common use-cases.
  *
- * <h1>Sampling</h1>
+ * <p>Sampling</p>
  * Sampling of traces and Spans can be done in two ways.
  * <p>
  * Firstly, the {@link SpanBuilderFactory} is configured with a "global" sampler
@@ -47,16 +47,16 @@ import java.util.ArrayList;
  * However, note that you do not have to use either of the sampling mechanisms and can always configure either one or
  * both to "always sample" with a {@code sampleRate} of 1 (e.g. {@link Sampling#alwaysSampler()} does this).
  *
- * <h1>Thread-safety</h1>
+ * <p>Thread-safety</p>
  * See {@link Tracer Tracer's notes on thread-safety}, as the same rules apply to this class.
  *
- * <h1>Propagation to other threads</h1>
+ * <p>Propagation to other threads</p>
  * Because of the use of thread-local context you might find traces breaking as you execute code asynchronously.
  * <p>
  * See {@link Tracer the Tracer's notes on propagation}, which details how to use its API to propagate your traces to
  * other threads.
  *
- * <h1>Propagation to other processes</h1>
+ * <p>Propagation to other processes</p>
  * For example, the <b>Spring Beeline</b> automatically accepts traces by decoding the Honeycomb trace header.
  * It also continues traces downstream when using Spring's RestTemplate.
  * <p>
@@ -85,7 +85,7 @@ public class Beeline {
      * Note, this method is null-safe - a "noop" span is returned if no trace is currently active. This may be due to
      * the current execution not being instrumented or because the trace was not sampled.
      *
-     * <h1>Example</h1>
+     * <p>Example</p>
      * <pre>
      * if (underAttack) {
      *      final Span currentSpan = beeline.getActiveSpan()
@@ -110,7 +110,7 @@ public class Beeline {
      * Because of the parent and child being linked by reference, the child's lifetime is tied and limited to that
      * of the parent.
      *
-     * <h1>Example</h1>
+     * <p>Example</p>
      * <pre>
      * // try-with-resources statement automatically closes the span
      * try (Span childSpan = beeline.startChildSpan("http-call")) {
@@ -134,7 +134,7 @@ public class Beeline {
      * This is to avoid clashes and distinguish it from standard fields provided by automatic instrumentations like
      * the "Spring Beeline".
      *
-     * <h1>Example</h1>
+     * <p>Example</p>
      * <pre>
      * if (underAttack) {
      *      beeline.addField("alert-message", "We are under attack!");

--- a/beeline-core/src/main/java/io/honeycomb/beeline/tracing/SendingSpan.java
+++ b/beeline-core/src/main/java/io/honeycomb/beeline/tracing/SendingSpan.java
@@ -18,7 +18,7 @@ import java.util.Map;
  * <p>
  * If you need to construct Spans of this type, you can make use {@link SpanBuilderFactory}.
  *
- * <h1>Thread-safety</h1>
+ * <p>Thread-safety</p>
  * Instances of this class are not thread-safe.
  */
 public class SendingSpan extends Span {

--- a/beeline-core/src/main/java/io/honeycomb/beeline/tracing/Span.java
+++ b/beeline-core/src/main/java/io/honeycomb/beeline/tracing/Span.java
@@ -16,7 +16,7 @@ import java.util.Map;
  * A Span represents an operation over its duration and associates the attributes contained within this class with it.
  * Subclasses of Span transparently implement the mechanism by which a Span is "closed" and submitted to Honeycomb.
  *
- * <h1>Thread-safety</h1>
+ * <p>Thread-safety</p>
  * Instances of this class are not thread-safe.
  */
 @SuppressWarnings({"ClassWithTooManyFields", "ClassWithTooManyMethods"})

--- a/beeline-core/src/main/java/io/honeycomb/beeline/tracing/SpanBuilderFactory.java
+++ b/beeline-core/src/main/java/io/honeycomb/beeline/tracing/SpanBuilderFactory.java
@@ -12,10 +12,10 @@ import java.util.HashMap;
 import java.util.Map;
 
 /**
- * <h1>Sampling</h1>
+ * <p>Sampling</p>
  * See the {@link Beeline} javadoc for details on sampling.
  *
- * <h1>Thread-safety</h1>
+ * <p>Thread-safety</p>
  * Instances of this class are thread-safe and can be shared. The SpanBuilder that it creates is not.
  */
 public class SpanBuilderFactory {
@@ -144,7 +144,7 @@ public class SpanBuilderFactory {
      * <p>
      * Spans are sampled on {@link #build}, based on the implementation of the configured {@link TraceSampler}.
      *
-     * <h1>Thread-safety</h1>
+     * <p>Thread-safety</p>
      * Instances of this class are not thread-safe.
      */
     @SuppressWarnings("ClassWithTooManyFields")

--- a/beeline-core/src/main/java/io/honeycomb/beeline/tracing/SpanPostProcessor.java
+++ b/beeline-core/src/main/java/io/honeycomb/beeline/tracing/SpanPostProcessor.java
@@ -10,7 +10,7 @@ import io.honeycomb.libhoney.utils.Assert;
  * This applies post processing to Spans that are ready to be sent. Namely, it can apply the {@code samplerHook} and
  * convert {@linkplain Span Spans} into {@link Event Events} that can be submitted to Honeycomb.
  *
- * <h1>Thread-safety</h1>
+ * <p>Thread-safety</p>
  * Instances of this class are thread-safe and can be shared.
  */
 public class SpanPostProcessor {

--- a/beeline-core/src/main/java/io/honeycomb/beeline/tracing/Tracer.java
+++ b/beeline-core/src/main/java/io/honeycomb/beeline/tracing/Tracer.java
@@ -21,7 +21,7 @@ import java.util.function.Supplier;
  * This class is meant to be used in conjunction with {@link SpanBuilderFactory}, which is capable of constructing the Span
  * arguments that must be passed into methods like {@link #startTrace(Span)}.
  *
- * <h1>Span vs. TracerSpan</h1>
+ * <p>Span vs. TracerSpan</p>
  * Some methods in this class return {@link TracerSpan}. This is done to clarify that such instances are now managed by
  * the Tracer and user code should no longer interact with the argument. in fact, TracerSpans generally act as
  * decorators around the Span arguments.
@@ -29,7 +29,7 @@ import java.util.function.Supplier;
  * <p>
  * On the other hand, where a method returns just Span, expect the instance to longer be managed by the tracer.
  *
- * <h1 id="thread-safety">Thread-safety</h1>
+ * <p id="thread-safety">Thread-safety</p>
  * This class is thread-safe so that it can be shared across the application. <strong>In fact, it is recommended to use
  * it as a singleton (e.g. as a singleton bean in Spring application), since thread-local state is tied to the instance
  * (it's an instance variable) and not the class (it is not static).</strong>. This state is the hierarchy of Spans
@@ -221,7 +221,7 @@ public class Tracer {
      * Note, this method is null-safe - a "noop" span is returned if no trace is currently active. This may be due to
      * startTrace not having been called, or because the trace was not sampled (see {@link SpanBuilderFactory}.
      *
-     * <h1>Example</h1>
+     * <p>Example</p>
      * <pre>
      * if (underAttack) {
      *      final Span currentSpan = tracer.getActiveSpan()
@@ -250,7 +250,7 @@ public class Tracer {
      * Because of the parent and child being linked by reference, the child's lifetime is tied and limited to that
      * of the parent.
      *
-     * <h1>Example</h1>
+     * <p>Example</p>
      * <pre>
      * // try-with-resources statement automatically closes the span
      * try (Span childSpan = tracer.startChildSpan("http-call")) {
@@ -283,7 +283,7 @@ public class Tracer {
      * <p>
      * If your computation does not cross thread boundaries {@link #startChildSpan(String)} may be more convenient.
      *
-     * <h1>Example</h1>
+     * <p>Example</p>
      * <pre>
      * final Span httpServiceSpan = tracer.startDetachedChildSpan("http-call");
      * httpServiceSpan.addField("http-url", url);
@@ -328,7 +328,7 @@ public class Tracer {
      * If run on the same thread while the current trace is still active this will simply start a new child span within
      * the current thread's context.
      *
-     * <h1>Example</h1>
+     * <p>Example</p>
      * <pre>
      * CompletableFuture.runAsync(tracer.traceRunnable("http-call", (){@code ->} httpClient.get(url)));
      * </pre>
@@ -408,7 +408,7 @@ public class Tracer {
      * If run on the same thread while the current trace is still active this will simply start a new child span within
      * the current thread's context.
      *
-     * <h1>Example</h1>
+     * <p>Example</p>
      * <pre>
      * Future{@code <Response>} responseFuture =
      *      executor.submit(tracer.traceCallable("http-call", (){@code ->} httpClient.get(url)));
@@ -468,7 +468,7 @@ public class Tracer {
      * If run on the same thread while the current trace is still active this will simply start a new child span within
      * the current thread's context.
      *
-     * <h1>Example</h1>
+     * <p>Example</p>
      * <pre>
      * CompletableFuture.supplyAsync(tracer.traceSupplier("http-call", (){@code ->} httpClient.get(url)))
      * </pre>
@@ -526,7 +526,7 @@ public class Tracer {
      * If run on the same thread while the current trace is still active this will simply start a new child span within
      * the current thread's context.
      *
-     * <h1>Example</h1>
+     * <p>Example</p>
      * <pre>
      * completableFuture.thenApply(tracer.traceFunction("handle-response", Converter::convertResponse));
      * </pre>
@@ -587,7 +587,7 @@ public class Tracer {
      * If run on the same thread while the current trace is still active this will simply start a new child span within
      * the current thread's context.
      *
-     * <h1>Example</h1>
+     * <p>Example</p>
      * <pre>
      * completableFuture.thenAccept(
      *      tracer.traceConsumer("handle-response", (response){@code ->} handleResponse(response)));

--- a/beeline-core/src/main/java/io/honeycomb/beeline/tracing/TracerSpan.java
+++ b/beeline-core/src/main/java/io/honeycomb/beeline/tracing/TracerSpan.java
@@ -17,7 +17,7 @@ import java.util.Map;
  * closed prior to invoking close on the delegate Span. This ensures that the TracerSpan can detach itself from the
  * Tracer context and perform any necessary cleanup.
  *
- * <h1>Thread-safety</h1>
+ * <p>Thread-safety</p>
  * Instances of this class are not thread-safe. See the notes on the {@link Tracer}'s javadoc for details.
  */
 @SuppressWarnings("ClassWithTooManyMethods") // We override all methods of Span, thus the method count is high.

--- a/beeline-core/src/main/java/io/honeycomb/beeline/tracing/ids/TraceIdProvider.java
+++ b/beeline-core/src/main/java/io/honeycomb/beeline/tracing/ids/TraceIdProvider.java
@@ -3,7 +3,7 @@ package io.honeycomb.beeline.tracing.ids;
 /**
  * Interface that produces IDs for traces and spans.
  *
- * <h1>Thread-safety</h1>
+ * <p>Thread-safety</p>
  * Implementations must be thread-safe and so that they can be shared.
  */
 public interface TraceIdProvider {

--- a/beeline-core/src/main/java/io/honeycomb/beeline/tracing/ids/UUIDTraceIdProvider.java
+++ b/beeline-core/src/main/java/io/honeycomb/beeline/tracing/ids/UUIDTraceIdProvider.java
@@ -6,7 +6,7 @@ import java.util.UUID;
  * Produces a random UUID (v4) string as trace IDs.
  * This is inline with Beeline instrumentations in other programming languages.
  *
- * <h1>Thread-safety</h1>
+ * <p>Thread-safety</p>
  * Instances of this class are thread-safe and can be shared.
  */
 @Deprecated

--- a/beeline-core/src/main/java/io/honeycomb/beeline/tracing/ids/W3CTraceIdProvider.java
+++ b/beeline-core/src/main/java/io/honeycomb/beeline/tracing/ids/W3CTraceIdProvider.java
@@ -8,7 +8,7 @@ import static io.honeycomb.libhoney.utils.ObjectUtils.isNullOrEmpty;
  * Creates Trace and Span IDs that conform to the W3C specification.
  * This is inline with Beeline instrumentations in other programming languages.
  *
- * <h1>Thread-safety</h1>
+ * <p>Thread-safety</p>
  * Instances of this class are thread-safe and can be shared.
  */
 public class W3CTraceIdProvider implements TraceIdProvider {

--- a/beeline-core/src/main/java/io/honeycomb/beeline/tracing/propagation/AWSPropagationCodec.java
+++ b/beeline-core/src/main/java/io/honeycomb/beeline/tracing/propagation/AWSPropagationCodec.java
@@ -16,7 +16,7 @@ import static io.honeycomb.libhoney.utils.ObjectUtils.isNullOrEmpty;
  * The design of this class avoids throwing exceptions in favour of logging warnings and returning null on encode
  * or an "empty context" on decode.
  *
- * <h1>Thread-safety</h1>
+ * <p>Thread-safety</p>
  * Instances of this class are thread-safe and can be shared.
  */
 public class AWSPropagationCodec implements PropagationCodec<Map<String, String>> {

--- a/beeline-core/src/main/java/io/honeycomb/beeline/tracing/propagation/CompositeHttpHeaderPropagator.java
+++ b/beeline-core/src/main/java/io/honeycomb/beeline/tracing/propagation/CompositeHttpHeaderPropagator.java
@@ -9,7 +9,7 @@ import java.util.Optional;
  * Codec that encompasses one or more codec implementations and applies each codec on
  * each call to encode and decode.
  *
- * <h1>Thread-safety</h1>
+ * <p>Thread-safety</p>
  * Instances of this class are thread-safe and can be shared.
  */
 public class CompositeHttpHeaderPropagator implements PropagationCodec<Map<String, String>> {

--- a/beeline-core/src/main/java/io/honeycomb/beeline/tracing/propagation/HttpHeaderV1PropagationCodec.java
+++ b/beeline-core/src/main/java/io/honeycomb/beeline/tracing/propagation/HttpHeaderV1PropagationCodec.java
@@ -29,7 +29,7 @@ import static io.honeycomb.libhoney.utils.ObjectUtils.isNullOrEmpty;
  * The design of this class avoids throwing exceptions in favour of logging warnings and returning null on encode
  * or an "empty context" on decode.
  *
- * <h1>Thread-safety</h1>
+ * <p>Thread-safety</p>
  * Instances of this class are thread-safe and can be shared.
  */
 public class HttpHeaderV1PropagationCodec implements PropagationCodec<Map<String, String>> {

--- a/beeline-core/src/main/java/io/honeycomb/beeline/tracing/propagation/PropagationCodec.java
+++ b/beeline-core/src/main/java/io/honeycomb/beeline/tracing/propagation/PropagationCodec.java
@@ -10,7 +10,7 @@ import java.util.Optional;
  * Since tracing instrumentation should not be invasive, implementations of this interface must avoid throwing
  * exceptions, and instead return "empty" return values - highlight issues through logging.
  *
- * <h1>Thread-safety</h1>
+ * <p>Thread-safety</p>
  * Implementations must be thread-safe and so that they can be shared.
  *
  * @param <E> Type of the transmission format to be decoded/encoded.

--- a/beeline-core/src/main/java/io/honeycomb/beeline/tracing/propagation/PropagationContext.java
+++ b/beeline-core/src/main/java/io/honeycomb/beeline/tracing/propagation/PropagationContext.java
@@ -20,7 +20,7 @@ import static io.honeycomb.libhoney.utils.ObjectUtils.isNullOrEmpty;
  * <li><em>Optional</em> - The name of the dataset to send the Spans to.
  * This acts as an override for the application's configured dataset.</li>
  * </ol>
- * <h1>Thread-safety</h1>
+ * <p>Thread-safety</p>
  * Instances of this class are thread-safe.
  */
 public class PropagationContext {

--- a/beeline-core/src/main/java/io/honeycomb/beeline/tracing/propagation/W3CPropagationCodec.java
+++ b/beeline-core/src/main/java/io/honeycomb/beeline/tracing/propagation/W3CPropagationCodec.java
@@ -25,7 +25,7 @@ import static io.honeycomb.libhoney.utils.ObjectUtils.isNullOrEmpty;
  * The design of this class avoids throwing exceptions in favour of logging warnings and returning null on encode
  * or an "empty context" on decode.
  *
- * <h1>Thread-safety</h1>
+ * <p>Thread-safety</p>
  * Instances of this class are thread-safe and can be shared.
  */
 public class W3CPropagationCodec implements PropagationCodec<Map<String, String>> {

--- a/beeline-core/src/main/java/io/honeycomb/beeline/tracing/sampling/DeterministicTraceSampler.java
+++ b/beeline-core/src/main/java/io/honeycomb/beeline/tracing/sampling/DeterministicTraceSampler.java
@@ -19,7 +19,7 @@ import java.security.NoSuchAlgorithmException;
  * This implementation is based on the implementations (and necessarily needs to be in line with) the other Beeline
  * implementations.
  *
- * <h1>Thread-safety</h1>
+ * <p>Thread-safety</p>
  * Instances of this class are thread-safe and can be shared.
  *
  * @see <a href="https://github.com/honeycombio/beeline-go/blob/main/sample/deterministic_sampler.go">

--- a/beeline-core/src/main/java/io/honeycomb/beeline/tracing/sampling/TraceSampler.java
+++ b/beeline-core/src/main/java/io/honeycomb/beeline/tracing/sampling/TraceSampler.java
@@ -3,7 +3,7 @@ package io.honeycomb.beeline.tracing.sampling;
 /**
  * Simple interface to test a given input and decide whether to sample it.
  *
- * <h1>Thread-safety</h1>
+ * <p>Thread-safety</p>
  * Implementations must be thread-safe and so that they can be shared.
  *
  * @param <T> type of input.

--- a/beeline-spring-boot-starter/src/main/java/io/honeycomb/beeline/spring/autoconfig/BeelineMetaFieldProvider.java
+++ b/beeline-spring-boot-starter/src/main/java/io/honeycomb/beeline/spring/autoconfig/BeelineMetaFieldProvider.java
@@ -20,7 +20,7 @@ import static io.honeycomb.beeline.tracing.utils.TraceFieldConstants.*;
  * This class class helps setting various "meta.*" fields so that all Spans and Events sent through the Beeline's
  * HoneyClient contain them.
  *
- * <h1>Laziness</h1>
+ * <p>Laziness</p>
  * Laziness here is used to avoid a circular dependency issue. Namely, this provider is required by the Beelines's
  * HoneyClient. But the provider requires itself a list of all BeelineInstrumentations. BeelineInstrumentations in turn
  * require HoneyClient to be already initialised.

--- a/beeline-spring-boot-starter/src/main/java/io/honeycomb/beeline/spring/beans/aspects/ChildSpan.java
+++ b/beeline-spring-boot-starter/src/main/java/io/honeycomb/beeline/spring/beans/aspects/ChildSpan.java
@@ -26,7 +26,7 @@ import java.lang.annotation.Target;
  * "https://docs.spring.io/spring/docs/current/spring-framework-reference/core.html#aop-understanding-aop-proxies">
  * "Understanding AOP Proxies</a> explains this mechanism.
  *
- * <h1>Example 1</h1>
+ * <p>Example 1</p>
  * <pre>
  * {@code @ChildSpan}
  *  public void doStuff({@code @SpanField} final String id,


### PR DESCRIPTION
While preparing the v1.15.0 release (#92), two issues were found that prevented it from successfully building on Circle CI:

1) The updated circle CI config used a new circle CI provided orb to do the pom.xml caching for us, unfortuently the command also executed a dependency check with a go-offline flag, which meant it needs to be able to resolve all dependencies from public sources; in our project the spring boot and sleuth packages depend on beeline-core, and as we were updating the beeline-core module too, it couldn't resolve it. This has been fixed by doing the caching ourselves and doing the dependency check as part of the testing.

2) We're now testing for Java 13, which has stricter javadoc rules and do not allow h1 tags in class & property comments. I've had to switch these over to regular p tags. They don't look as nice, but they work.