### PR TITLE
Use public CircleCI context for build secrets

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -109,7 +109,7 @@ workflows:
             branches:
               ignore: /.*/
       - publish_github:
-          context: Honeycomb Secrets
+          context: Honeycomb Secrets for Public Repos
           requires:
             - package
           filters: *tag_filters


### PR DESCRIPTION
* we created a new public context that's identical to the old context,
with the exception of Github token, which is scoped to public repos only
* Github token in the other context is scoped to public and private repos
* (both contexts are still internal to Honeycomb)
* this reduces the security exposure of builds