### PR TITLE
Change Brave span transforming to properly associate spans

### DIFF
--- a/beeline-spring-boot-sleuth-starter/src/main/java/io/honeycomb/beeline/spring/beans/BraveBeelineReporter.java
+++ b/beeline-spring-boot-sleuth-starter/src/main/java/io/honeycomb/beeline/spring/beans/BraveBeelineReporter.java
@@ -71,7 +71,7 @@ public class BraveBeelineReporter implements Reporter<Span> {
         );
         final Long startTimestamp = span.timestamp();
         if (startTimestamp != null && startTimestamp > 0) {
-            hcRootSpan.markStart(startTimestamp/1000, startTimestamp/1000);
+            hcRootSpan.markStart(startTimestamp/MICROS_IN_MILLISECOND, startTimestamp/MICROS_IN_MILLISECOND);
         }
         if (span.durationAsLong() > 0) {
             // Brave uses zero for no timestamp

--- a/beeline-spring-boot-sleuth-starter/src/main/java/io/honeycomb/beeline/spring/beans/BraveBeelineReporter.java
+++ b/beeline-spring-boot-sleuth-starter/src/main/java/io/honeycomb/beeline/spring/beans/BraveBeelineReporter.java
@@ -60,11 +60,18 @@ public class BraveBeelineReporter implements Reporter<Span> {
     }
 
     private io.honeycomb.beeline.tracing.Span transformBraveSpanToHoneycombSpan(final Span span) {
-        final PropagationContext propagationContext = new PropagationContext(span.traceId(), span.id(), null, null);
-        final io.honeycomb.beeline.tracing.Span hcRootSpan = beeline.startTrace(span.name(), propagationContext, properties.getServiceName());
-        final long startTimestamp = span.timestamp();
-        if (startTimestamp > 0) {
-            hcRootSpan.markStart(startTimestamp, startTimestamp);
+        final PropagationContext propagationContext = new PropagationContext(span.traceId(), span.parentId(), null, null);
+        final io.honeycomb.beeline.tracing.Span hcRootSpan = beeline.getTracer().startTrace(
+            beeline.getSpanBuilderFactory().createBuilder()
+                .setSpanName(span.name())
+                .setServiceName(properties.getServiceName())
+                .setParentContext(propagationContext)
+                .setSpanId(span.id())
+                .build()
+        );
+        final Long startTimestamp = span.timestamp();
+        if (startTimestamp != null && startTimestamp > 0) {
+            hcRootSpan.markStart(startTimestamp/1000, startTimestamp/1000);
         }
         if (span.durationAsLong() > 0) {
             // Brave uses zero for no timestamp


### PR DESCRIPTION
PR #87 submitted by @tyler-boyd had some failing tests.

This PR supersedes Tyler's PR by providing the same commit to update the BraveBeelineReporter to correctly use the span's parent ID to create the propagation context and fixes the broken tests.