### PR TITLE
Default w3c sampled flag to 01

### DIFF
--- a/beeline-core/src/main/java/io/honeycomb/beeline/tracing/propagation/W3CPropagationCodec.java
+++ b/beeline-core/src/main/java/io/honeycomb/beeline/tracing/propagation/W3CPropagationCodec.java
@@ -173,7 +173,7 @@ public class W3CPropagationCodec implements PropagationCodec<Map<String, String>
             return Optional.empty();
         }
 
-        final String traceParent = String.join(SEGMENT_SEPARATOR, DEFAULT_VERSION, context.getTraceId(), context.getSpanId(), NOT_SAMPLED_TRACEFLAGS);
+        final String traceParent = String.join(SEGMENT_SEPARATOR, DEFAULT_VERSION, context.getTraceId(), context.getSpanId(), SAMPLED_TRACEFLAGS);
 
         // If no dataset or tracefields, just return trace parent header
         if (context.getDataset() == null && context.getTraceFields().isEmpty()) {

--- a/beeline-core/src/test/java/io/honeycomb/beeline/tracing/propagation/W3CPropagationCodecTest.java
+++ b/beeline-core/src/test/java/io/honeycomb/beeline/tracing/propagation/W3CPropagationCodecTest.java
@@ -243,7 +243,7 @@ public class W3CPropagationCodecTest {
         final Map<String, String> encoded = codec.encode(new PropagationContext(traceId, spanId, null, null)).get();
 
         assertThat(encoded).isEqualTo(
-            Collections.singletonMap(W3CPropagationCodec.W3C_TRACEPARENT_HEADER, String.join("-", "00", traceId, spanId, "00"))
+            Collections.singletonMap(W3CPropagationCodec.W3C_TRACEPARENT_HEADER, String.join("-", "00", traceId, spanId, "01"))
         );
     }
 
@@ -254,11 +254,11 @@ public class W3CPropagationCodecTest {
         String dataset = "test-dataset";
 
         final Map<String, String> headers = new HashMap<>();
-        headers.put(W3CPropagationCodec.W3C_TRACEPARENT_HEADER, String.join("-", "00", traceId, spanId, "00"));
+        headers.put(W3CPropagationCodec.W3C_TRACEPARENT_HEADER, String.join("-", "00", traceId, spanId, "01"));
         headers.put(W3CPropagationCodec.W3C_TRACESTATE_HEADER, "hny=ZGF0YXNldD10ZXN0LWRhdGFzZXQ=");
 
         final Map<String, String> encoded = codec.encode(new PropagationContext(traceId, spanId, dataset, null)).get();
-        assertThat(headers).isEqualTo(encoded);
+        assertThat(encoded).isEqualTo(headers);
     }
 
     @Test
@@ -270,11 +270,11 @@ public class W3CPropagationCodecTest {
         fields.put("one", "two");
 
         final Map<String, String> headers = new HashMap<>();
-        headers.put(W3CPropagationCodec.W3C_TRACEPARENT_HEADER, String.join("-", "00", traceId, spanId, "00"));
+        headers.put(W3CPropagationCodec.W3C_TRACEPARENT_HEADER, String.join("-", "00", traceId, spanId, "01"));
         headers.put(W3CPropagationCodec.W3C_TRACESTATE_HEADER, "hny=Zm9vPWJhcixvbmU9dHdv");
 
         final Map<String, String> encoded = codec.encode(new PropagationContext(traceId, spanId, null, fields)).get();
-        assertThat(headers).isEqualTo(encoded);
+        assertThat(encoded).isEqualTo(headers);
     }
 
     @Test
@@ -287,10 +287,10 @@ public class W3CPropagationCodecTest {
         fields.put("one", "two");
 
         final Map<String, String> headers = new HashMap<>();
-        headers.put(W3CPropagationCodec.W3C_TRACEPARENT_HEADER, String.join("-", "00", traceId, spanId, "00"));
+        headers.put(W3CPropagationCodec.W3C_TRACEPARENT_HEADER, String.join("-", "00", traceId, spanId, "01"));
         headers.put(W3CPropagationCodec.W3C_TRACESTATE_HEADER,  "hny=ZGF0YXNldD10ZXN0LWRhdGFzZXQsZm9vPWJhcixvbmU9dHdv");
 
         final Map<String, String> encoded = codec.encode(new PropagationContext(traceId, spanId, dataset, fields)).get();
-        assertThat(headers).isEqualTo(encoded);
+        assertThat(encoded).isEqualTo(headers);
     }
 }


### PR DESCRIPTION
Receiving OTEL instrumentation ignores spans coming with the `00` sampled flag.

This is a stop-gap measure to ensure w3c parser hooks work with an OTEL receiver. Ideally, we would like to set the sampled flag based on an actual sampler, but that requires further investigation.