### PR TITLE
Improve end trace logging

### DIFF
--- a/CONTRIBUTORS
+++ b/CONTRIBUTORS
@@ -3,3 +3,4 @@ honeycombio/beeline-java contributors:
 Christian Jank
 Thomas O'Hagan
 Peter Royal
+[Andy Coates](https://github.com/big-andy-coates)

--- a/beeline-core/src/main/java/io/honeycomb/beeline/tracing/Tracer.java
+++ b/beeline-core/src/main/java/io/honeycomb/beeline/tracing/Tracer.java
@@ -204,8 +204,10 @@ public class Tracer {
             If all child spans have been closed properly, we should end up back at the "root" span, so stack size should
             be 1. This is because TracerSpan#close always sets the parentSpan as the new active span.
             The child spans will be closed as a result of calling close on the root.
+            While there may be multiple nested open spans, just log the most nested to allow the user to track it down.
             */
-            LOG.warn("Called #endTrace while the root span had active child spans.");
+            final String childSpan = tracingContext.peekFirst().getSpanName();
+            LOG.warn("Called #endTrace while the root span had active child spans. Open span name: {}", childSpan);
         }
         if (tracingContext.size() >= 1) {
             LOG.debug("Ending trace");


### PR DESCRIPTION
Adds the name of the most nested open span when ending trace with active child spans.

Trying to work out which span has incorrectly not been closed can be a PITA. So let's make it a little easier by logging the most nested child span's name.

This is a small _logging only_ change, with no obvious way of unit testing unless we inject the logger.  Let me know if you're happy for this to not have a unit test.  All existing tests pass.


