### PR TITLE
ci: fix maven release

### DIFF
--- a/.circleci/maven-release-settings.xml
+++ b/.circleci/maven-release-settings.xml
@@ -9,7 +9,7 @@
 
     <profiles>
         <profile>
-            <id>gpg</id>
+            <id>release</id>
             <properties>
                 <gpg.executable>gpg</gpg.executable>
                 <gpg.passphrase>${env.GPG_PASSPHRASE}</gpg.passphrase>
@@ -17,6 +17,6 @@
         </profile>
     </profiles>
     <activeProfiles>
-        <activeProfile>gpg</activeProfile>
+        <activeProfile>release</activeProfile>
     </activeProfiles>
 </settings>


### PR DESCRIPTION
<!--
Thank you for contributing to the project! 💜
Please make sure to:
- Chat with us first if this is a big change
  - Open a new issue (or comment on an existing one)
  - We want to make sure you don't spend time implementing something we might have to say No to
- Add unit tests
- Mention any relevant issues in the PR description (e.g. "Fixes #123")

Please see our [OSS process document](https://github.com/honeycombio/home/blob/main/honeycomb-oss-lifecycle-and-practices.md#) to get an idea of how we operate.
-->

## Which problem is this PR solving?

- fixes #157 

## Short description of the changes

- release plugins in the parent pom.xml were configured for the `release` profile, but we were setting active profile to `gpg` in the release-settings.xml
- verified locally by publishing the 1.6.1 artifacts
