### PR TITLE
feat: parse both w3c and honeycomb propagation headers by default

### DIFF
--- a/beeline-core/src/main/java/io/honeycomb/beeline/tracing/propagation/BeelineServletFilter.java
+++ b/beeline-core/src/main/java/io/honeycomb/beeline/tracing/propagation/BeelineServletFilter.java
@@ -334,7 +334,7 @@ public class BeelineServletFilter implements Filter {
             requestToRedispatchSpanName = DEFAULT_REDISPATCH_SPAN_NAMING_FUNCTION;
         private Function<io.honeycomb.beeline.tracing.propagation.HttpServerRequestAdapter,
             String> requestToSpanName = DEFAULT_REQUEST_SPAN_NAMING_FUNCTION;
-        private PropagationCodec<Map<String, String>> propagationCodec = Propagation.honeycombHeaderV1();
+        private PropagationCodec<Map<String, String>> propagationCodec = Propagation.defaultHeader();
 
         /**
          * Set the name of the service using the filter. Required.

--- a/beeline-core/src/main/java/io/honeycomb/beeline/tracing/propagation/DefaultPropagationCodec.java
+++ b/beeline-core/src/main/java/io/honeycomb/beeline/tracing/propagation/DefaultPropagationCodec.java
@@ -1,0 +1,39 @@
+package io.honeycomb.beeline.tracing.propagation;
+
+import java.util.Map;
+import java.util.Optional;
+
+public class DefaultPropagationCodec implements PropagationCodec<Map<String, String>> {
+
+    private static final DefaultPropagationCodec INSTANCE = new DefaultPropagationCodec();
+    protected static final String CODEC_NAME = "default";
+
+    public static DefaultPropagationCodec getInstance() {
+        return INSTANCE;
+    }
+
+    /**
+     * Gets the codec name.
+     */
+    public String getName() {
+        return CODEC_NAME;
+    }
+
+    @Override
+    public PropagationContext decode(Map<String, String> headers) {
+        PropagationContext w3cContext = W3CPropagationCodec.getInstance().decode(headers);
+        PropagationContext honeycombContext = HttpHeaderV1PropagationCodec.getInstance().decode(headers);
+
+        if (!honeycombContext.equals(PropagationContext.emptyContext())) {
+            return honeycombContext;
+        } else {
+            return w3cContext;
+        }
+    }
+
+    @Override
+    public Optional<Map<String, String>> encode(PropagationContext context) {
+        return HttpHeaderV1PropagationCodec.getInstance().encode(context);
+    }
+
+}

--- a/beeline-core/src/main/java/io/honeycomb/beeline/tracing/propagation/HttpClientPropagator.java
+++ b/beeline-core/src/main/java/io/honeycomb/beeline/tracing/propagation/HttpClientPropagator.java
@@ -53,7 +53,7 @@ public class HttpClientPropagator {
      * @param requestToSpanName a function from request to span name
      */
     public HttpClientPropagator(final Tracer tracer, final Function<HttpClientRequestAdapter, String> requestToSpanName) {
-        this(tracer, Propagation.honeycombHeaderV1(), requestToSpanName, null);
+        this(tracer, Propagation.defaultHeader(), requestToSpanName, null);
     }
 
     // Used by builder
@@ -147,7 +147,7 @@ public class HttpClientPropagator {
 
         private Tracer tracer;
         private Function<HttpClientRequestAdapter, String> requestToSpanName;
-        private PropagationCodec<Map<String, String>> propagationCodec = Propagation.honeycombHeaderV1();
+        private PropagationCodec<Map<String, String>> propagationCodec = Propagation.defaultHeader();
         private BiFunction<HttpClientRequestAdapter, PropagationContext, Optional<Map<String, String>>> tracePropagationHook = null;
 
         /**

--- a/beeline-core/src/main/java/io/honeycomb/beeline/tracing/propagation/HttpHeaderPropagationCodecFactory.java
+++ b/beeline-core/src/main/java/io/honeycomb/beeline/tracing/propagation/HttpHeaderPropagationCodecFactory.java
@@ -7,22 +7,26 @@ import java.util.Map;
 public class HttpHeaderPropagationCodecFactory {
 
     /**
-     * Factory method to create a HTTP header {@link PropagationCodec} from a list of codec names.
+     * Factory method to create a HTTP header {@link PropagationCodec} from a list
+     * of codec names.
      * <p>
-     * Returns a {@link HttpHeaderPropagationCodecFactory} if no valid codec names are provided.
+     * Returns a {@link HttpHeaderPropagationCodecFactory} if no valid codec names
+     * are provided.
      * </p>
-     * Returns a {@link CompositeHttpHeaderPropagtor} if more than one valid codec is provided.
+     * Returns a {@link CompositeHttpHeaderPropagtor} if more than one valid codec
+     * is provided.
+     *
      * @param propagatorNames the named of the codecs to use
      * @return a propagtion codec to be used to parse and propagate trace data.
      */
     public static PropagationCodec<Map<String, String>> create(final List<String> propagatorNames) {
         if (propagatorNames == null || propagatorNames.isEmpty()) {
-            return Propagation.honeycombHeaderV1();
+            return Propagation.defaultHeader();
         }
 
         List<PropagationCodec<Map<String, String>>> codecs = new ArrayList<>();
         for (String codecName : propagatorNames) {
-            switch(codecName) {
+            switch (codecName) {
                 case AWSPropagationCodec.CODEC_NAME:
                     codecs.add(Propagation.aws());
                     break;
@@ -32,15 +36,18 @@ public class HttpHeaderPropagationCodecFactory {
                 case W3CPropagationCodec.CODEC_NAME:
                     codecs.add(Propagation.w3c());
                     break;
+                case DefaultPropagationCodec.CODEC_NAME:
+                    codecs.add(Propagation.defaultHeader());
+                    break;
                 default:
                     continue;
             }
         }
 
-        switch(codecs.size()) {
+        switch (codecs.size()) {
             case 0:
-                // if no codecs, default to honeycomb
-                return Propagation.honeycombHeaderV1();
+                // if no codecs, default to (honeycomb or w3c, honeycomb takes precedence)
+                return Propagation.defaultHeader();
             case 1:
                 // if only one codec, return it directly
                 return codecs.get(0);

--- a/beeline-core/src/main/java/io/honeycomb/beeline/tracing/propagation/HttpServerPropagator.java
+++ b/beeline-core/src/main/java/io/honeycomb/beeline/tracing/propagation/HttpServerPropagator.java
@@ -2,6 +2,7 @@ package io.honeycomb.beeline.tracing.propagation;
 
 import io.honeycomb.beeline.tracing.Beeline;
 import io.honeycomb.beeline.tracing.Span;
+import io.honeycomb.libhoney.shaded.org.apache.http.Header;
 import io.honeycomb.libhoney.shaded.org.apache.http.HttpHeaders;
 
 import java.util.Map;
@@ -10,25 +11,31 @@ import java.util.function.Function;
 import static io.honeycomb.beeline.tracing.utils.TraceFieldConstants.*;
 
 /**
- * Provides straightforward instrumentation of an an HTTP server, while also adding a
+ * Provides straightforward instrumentation of an an HTTP server, while also
+ * adding a
  * standardized set of span fields.
  *
- * <p>Example instrumentation for synchronous server code:
- * <pre>{@code
- * HttpServerRequestAdapter adaptedHttpRequest = new HttpServerRequestAdapter(actualHttpRequest);
- * HttpServerResponseAdapter adaptedHttpResponse = null;
- * Throwable error = null;
- * Span span = serverPropagator.startPropagation(adaptedHttpRequest);
- * try {
- *   actualHttpResponse = doServerWork(actualHttpRequest);
- *   adaptedHttpResponse = new HttpServerResponseAdapter(actualHttpResponse);
- * } catch (Exception ex) {
- *   error = ex;
- *   throw ex;
- * } finally {
- *   serverPropagator.endPropagation(adaptedHttpResponse, error, span);
+ * <p>
+ * Example instrumentation for synchronous server code:
+ *
+ * <pre>
+ * {
+ *     &#64;code
+ *     HttpServerRequestAdapter adaptedHttpRequest = new HttpServerRequestAdapter(actualHttpRequest);
+ *     HttpServerResponseAdapter adaptedHttpResponse = null;
+ *     Throwable error = null;
+ *     Span span = serverPropagator.startPropagation(adaptedHttpRequest);
+ *     try {
+ *         actualHttpResponse = doServerWork(actualHttpRequest);
+ *         adaptedHttpResponse = new HttpServerResponseAdapter(actualHttpResponse);
+ *     } catch (Exception ex) {
+ *         error = ex;
+ *         throw ex;
+ *     } finally {
+ *         serverPropagator.endPropagation(adaptedHttpResponse, error, span);
+ *     }
  * }
- * }</pre>
+ * </pre>
  *
  * <p>
  * The API is based on Brave's HTTP utilities under {@code brave.http}.
@@ -44,28 +51,31 @@ public class HttpServerPropagator {
     private final Function<HttpServerRequestAdapter, PropagationContext> traceParserHook;
 
     /**
-     * Create an HttpServerPropagator for tracing requests received by an HTTP server.
+     * Create an HttpServerPropagator for tracing requests received by an HTTP
+     * server.
      * <p>
-     * {@code requestToSpanName} allows you to dynamically name the HTTP server span such that the name
+     * {@code requestToSpanName} allows you to dynamically name the HTTP server span
+     * such that the name
      * reflects the operation, e.g. based on HTTP method or request path used.
      *
-     * @param beeline the beeline
-     * @param serviceName the service name
+     * @param beeline           the beeline
+     * @param serviceName       the service name
      * @param requestToSpanName a function from an HTTP request to a span name
      */
     public HttpServerPropagator(final Beeline beeline,
-                                final String serviceName,
-                                final Function<HttpServerRequestAdapter, String> requestToSpanName) {
-        this(serviceName, requestToSpanName, new HttpServerRequestSpanCustomizer(), Propagation.honeycombHeaderV1(), null, beeline);
+            final String serviceName,
+            final Function<HttpServerRequestAdapter, String> requestToSpanName) {
+        this(serviceName, requestToSpanName, new HttpServerRequestSpanCustomizer(), Propagation.defaultHeader(),
+                null, beeline);
     }
 
     // Used by builder
     protected HttpServerPropagator(final String serviceName,
-                                final Function<HttpServerRequestAdapter, String> requestToSpanName,
-                                final HttpServerRequestSpanCustomizer spanCustomizer,
-                                final PropagationCodec<Map<String, String>> propagationCodec,
-                                final Function<HttpServerRequestAdapter, PropagationContext> traceParserHook,
-                                final Beeline beeline) {
+            final Function<HttpServerRequestAdapter, String> requestToSpanName,
+            final HttpServerRequestSpanCustomizer spanCustomizer,
+            final PropagationCodec<Map<String, String>> propagationCodec,
+            final Function<HttpServerRequestAdapter, PropagationContext> traceParserHook,
+            final Beeline beeline) {
         this.requestToSpanName = requestToSpanName;
         this.serviceName = serviceName;
         this.spanCustomizer = spanCustomizer;
@@ -75,13 +85,14 @@ public class HttpServerPropagator {
     }
 
     /**
-     * Creates a root span for this HTTP server call and adds the standardized fields to it.
+     * Creates a root span for this HTTP server call and adds the standardized
+     * fields to it.
      *
      * @param httpRequest the adapted HTTP request
      * @return the span
      */
     public Span startPropagation(final HttpServerRequestAdapter httpRequest) {
-        //PropagationCodec#decode is null-safe
+        // PropagationCodec#decode is null-safe
         final PropagationContext decoded;
         if (traceParserHook == null) {
             decoded = propagationCodec.decode(httpRequest.getHeaders());
@@ -98,14 +109,17 @@ public class HttpServerPropagator {
     }
 
     /**
-     * Adds standard span fields based on data in the HTTP response or the {@code error}.
+     * Adds standard span fields based on data in the HTTP response or the
+     * {@code error}.
      * Closes the HTTP server span.
      * <p>
-     * The {@code httpResponse} and the {@code error} are both allowed to be {@code null}.
+     * The {@code httpResponse} and the {@code error} are both allowed to be
+     * {@code null}.
      *
      * @param httpResponse the adapted HTTP response, may be {@code null}
-     * @param error an error that was thrown when the HTTP server was processing the HTTP request, may be {@code null}
-     * @param span the span for the HTTP server call
+     * @param error        an error that was thrown when the HTTP server was
+     *                     processing the HTTP request, may be {@code null}
+     * @param span         the span for the HTTP server call
      */
     public void endPropagation(final HttpServerResponseAdapter httpResponse, final Throwable error, final Span span) {
         try {
@@ -119,7 +133,8 @@ public class HttpServerPropagator {
                     span.addField(REQUEST_ERROR_DETAIL_FIELD, error.getMessage());
                 }
             } else if (httpResponse != null) {
-                httpResponse.getFirstHeader(HttpHeaders.CONTENT_TYPE).ifPresent(v -> span.addField(RESPONSE_CONTENT_TYPE_FIELD, v));
+                httpResponse.getFirstHeader(HttpHeaders.CONTENT_TYPE)
+                        .ifPresent(v -> span.addField(RESPONSE_CONTENT_TYPE_FIELD, v));
                 span.addField(STATUS_CODE_FIELD, httpResponse.getStatus());
             }
         } finally {
@@ -136,16 +151,19 @@ public class HttpServerPropagator {
         private final String serviceName;
         private final Function<HttpServerRequestAdapter, String> requestToSpanName;
         private HttpServerRequestSpanCustomizer spanCustomizer = new HttpServerRequestSpanCustomizer();
-        private PropagationCodec<Map<String, String>> propagationCodec = Propagation.honeycombHeaderV1();;
+        private PropagationCodec<Map<String, String>> propagationCodec = Propagation.defaultHeader();;
         private Function<HttpServerRequestAdapter, PropagationContext> traceParserHook = null;
 
         /**
          * Creates a new instance of {@link HttpServerPropagator.Builder}.
-         * @param beeline the beeline
-         * @param serviceName the service name
-         * @param requestToSpanName function to get a span name from a {@link HttpServerRequestAdapter}
+         *
+         * @param beeline           the beeline
+         * @param serviceName       the service name
+         * @param requestToSpanName function to get a span name from a
+         *                          {@link HttpServerRequestAdapter}
          */
-        public Builder(Beeline beeline, String serviceName, Function<HttpServerRequestAdapter, String> requestToSpanName) {
+        public Builder(Beeline beeline, String serviceName,
+                Function<HttpServerRequestAdapter, String> requestToSpanName) {
             this.beeline = beeline;
             this.serviceName = serviceName;
             this.requestToSpanName = requestToSpanName;
@@ -153,6 +171,7 @@ public class HttpServerPropagator {
 
         /**
          * Set the {@link HttpServerRequestSpanCustomizer} used to customize a span.
+         *
          * @param spanCustomizer the span customizer
          * @return the {@link HttpServerPropagator.Builder} to be used for chaining
          */
@@ -162,7 +181,9 @@ public class HttpServerPropagator {
         }
 
         /**
-         * Set the {@link PropagationCodec} to encode/decode trace context via HTTP headers.
+         * Set the {@link PropagationCodec} to encode/decode trace context via HTTP
+         * headers.
+         *
          * @param propagationCodec the propagation codec
          * @return the {@link HttpServerPropagator.Builder} to be used for chaining
          */
@@ -173,6 +194,7 @@ public class HttpServerPropagator {
 
         /**
          * Set a custom function used to parse trace context on incoming HTTP requests.
+         *
          * @param traceParserHook the trace parse hook
          * @return the {@link HttpServerPropagator.Builder} to be used for chaining
          */
@@ -183,10 +205,12 @@ public class HttpServerPropagator {
 
         /**
          * Builds a {@link HttpServerPropagator} using the provided parameters.
+         *
          * @return a new instance of {@link HttpServerPropagator}
          */
         public HttpServerPropagator build() {
-            return new HttpServerPropagator(serviceName, requestToSpanName, spanCustomizer, propagationCodec, traceParserHook, beeline);
+            return new HttpServerPropagator(serviceName, requestToSpanName, spanCustomizer, propagationCodec,
+                    traceParserHook, beeline);
         }
     }
 }

--- a/beeline-core/src/main/java/io/honeycomb/beeline/tracing/propagation/HttpServerPropagator.java
+++ b/beeline-core/src/main/java/io/honeycomb/beeline/tracing/propagation/HttpServerPropagator.java
@@ -20,7 +20,7 @@ import static io.honeycomb.beeline.tracing.utils.TraceFieldConstants.*;
  *
  * <pre>
  * {
- *     &#64;code
+ *     @code
  *     HttpServerRequestAdapter adaptedHttpRequest = new HttpServerRequestAdapter(actualHttpRequest);
  *     HttpServerResponseAdapter adaptedHttpResponse = null;
  *     Throwable error = null;

--- a/beeline-core/src/main/java/io/honeycomb/beeline/tracing/propagation/Propagation.java
+++ b/beeline-core/src/main/java/io/honeycomb/beeline/tracing/propagation/Propagation.java
@@ -18,29 +18,42 @@ public final class Propagation {
     }
 
     /**
-     * Codec that can decode/encode trace context based on Version 1 of the Honeycomb http header ('x-honeycomb-trace').
+     * Codec that can decode/encode trace context based on Version 1 of the
+     * Honeycomb http header ('x-honeycomb-trace').
      *
      * @return a codec.
      */
-    public static PropagationCodec<Map<String,String>> honeycombHeaderV1() {
+    public static PropagationCodec<Map<String, String>> honeycombHeaderV1() {
         return HttpHeaderV1PropagationCodec.getInstance();
     }
 
     /**
-     * Codec that can decode/encode trace context based on the AWS http header ('X-Amzn-Trace-Id').
+     * Codec that can decode/encode trace context based on the AWS http header
+     * ('X-Amzn-Trace-Id').
      *
      * @return a codec.
      */
-    public static PropagationCodec<Map<String,String>> aws() {
+    public static PropagationCodec<Map<String, String>> aws() {
         return AWSPropagationCodec.getInstance();
     }
 
     /**
-     * Codec that can decode/encode trace context based on Version 1 of the W3C http header ('traceparent').
+     * Codec that can decode/encode trace context based on Version 1 of the W3C http
+     * header ('traceparent').
      *
      * @return a codec.
      */
-    public static PropagationCodec<Map<String,String>> w3c() {
+    public static PropagationCodec<Map<String, String>> w3c() {
         return W3CPropagationCodec.getInstance();
+    }
+
+    /**
+     * Codec that can decode/encode trace context based on Version 1 of the W3C http
+     * header ('traceparent').
+     *
+     * @return a codec.
+     */
+    public static PropagationCodec<Map<String, String>> defaultHeader() {
+        return DefaultPropagationCodec.getInstance();
     }
 }

--- a/beeline-core/src/main/java/io/honeycomb/beeline/tracing/propagation/Propagation.java
+++ b/beeline-core/src/main/java/io/honeycomb/beeline/tracing/propagation/Propagation.java
@@ -38,7 +38,7 @@ public final class Propagation {
     }
 
     /**
-     * Codec that can decode/encode trace context based on Version 1 of the W3C http
+     * Codec that can decode/encode trace context based on the W3C http
      * header ('traceparent').
      *
      * @return a codec.
@@ -48,7 +48,8 @@ public final class Propagation {
     }
 
     /**
-     * Codec that can decode/encode trace context based on Version 1 of the W3C http
+     * Codec that can decode/encode trace context based on Version 1 of the
+     * Honeycomb http header ('x-honeycomb-trace') or the W3C http
      * header ('traceparent').
      *
      * @return a codec.

--- a/beeline-core/src/test/java/io/honeycomb/beeline/tracing/propagation/HttpHeaderPropagationCodecFactoryTest.java
+++ b/beeline-core/src/test/java/io/honeycomb/beeline/tracing/propagation/HttpHeaderPropagationCodecFactoryTest.java
@@ -10,18 +10,20 @@ import org.junit.Test;
 
 public class HttpHeaderPropagationCodecFactoryTest {
     @Test
-    public void GIVEN_nullPropagtorNames_EXPECT_honeycombV1Propagator() {
-        assertThat(HttpHeaderPropagationCodecFactory.create(null)).isEqualTo(Propagation.honeycombHeaderV1());
+    public void GIVEN_nullPropagatorNames_EXPECT_defaultPropagator() {
+        assertThat(HttpHeaderPropagationCodecFactory.create(null)).isEqualTo(Propagation.defaultHeader());
     }
 
     @Test
-    public void GIVEN_emptyPropagatorNames_EXPECT_honeycombV1Propagator() {
-        assertThat(HttpHeaderPropagationCodecFactory.create(Collections.emptyList())).isEqualTo(Propagation.honeycombHeaderV1());
+    public void GIVEN_emptyPropagatorNames_EXPECT_defaultPropagator() {
+        assertThat(HttpHeaderPropagationCodecFactory.create(Collections.emptyList()))
+                .isEqualTo(Propagation.defaultHeader());
     }
 
     @Test
-    public void GIVEN_invalidPropagatorNames_EXPECT_honeycombV1Propagator() {
-        assertThat(HttpHeaderPropagationCodecFactory.create(Collections.singletonList("unknown"))).isEqualTo(Propagation.honeycombHeaderV1());
+    public void GIVEN_invalidPropagatorNames_EXPECT_defaultPropagator() {
+        assertThat(HttpHeaderPropagationCodecFactory.create(Collections.singletonList("unknown")))
+                .isEqualTo(Propagation.defaultHeader());
     }
 
     @Test
@@ -37,6 +39,13 @@ public class HttpHeaderPropagationCodecFactoryTest {
     @Test
     public void GIVEN_w3cAsPropagatorName_EXPECT_singleImplementationOfPropagator() {
         assertThat(HttpHeaderPropagationCodecFactory.create(Collections.singletonList(W3CPropagationCodec.CODEC_NAME))).isEqualTo(Propagation.w3c());
+    }
+
+    @Test
+    public void GIVEN_defaultAsPropagatorName_EXPECT_singleImplementationOfPropagator() {
+        assertThat(
+                HttpHeaderPropagationCodecFactory.create(Collections.singletonList(DefaultPropagationCodec.CODEC_NAME)))
+                        .isEqualTo(Propagation.defaultHeader());
     }
 
     @Test

--- a/beeline-core/src/test/java/io/honeycomb/beeline/tracing/propagation/PropagationTest.java
+++ b/beeline-core/src/test/java/io/honeycomb/beeline/tracing/propagation/PropagationTest.java
@@ -9,4 +9,9 @@ public class PropagationTest {
     public void honeycombHeaderV1() {
         assertThat(Propagation.honeycombHeaderV1()).isInstanceOf(HttpHeaderV1PropagationCodec.class);
     }
+
+    @Test
+    public void defaultHeader() {
+        assertThat(Propagation.defaultHeader()).isInstanceOf(DefaultPropagationCodec.class);
+    }
 }


### PR DESCRIPTION
<!--
Thank you for contributing to the project! 💜
Please make sure to:
- Chat with us first if this is a big change
  - Open a new issue (or comment on an existing one)
  - We want to make sure you don't spend time implementing something we might have to say No to
- Add unit tests
- Mention any relevant issues in the PR description (e.g. "Fixes #123")

Please see our [OSS process document](https://github.com/honeycombio/home/blob/main/honeycomb-oss-lifecycle-and-practices.md#) to get an idea of how we operate.
-->

## Which problem is this PR solving?

- closes #165 

## Short description of the changes

- Adds default codec to parse either Honeycomb (if specified) or W3C trace propagation header. If both are present, Honeycomb header will be parsed.

