### PR TITLE
Prepare v1.7.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,25 @@
 # Beeline Changelog
 
+## [1.7.0] - 2021-12-23
+
+### Improvements
+
+- feat: parse both w3c and honeycomb propagation headers by default (#170) | [@JamieDanielson](https://github.com/JamieDanielson)
+
+### Maintenance
+
+- Bump pmdCoreVersion from 6.40.0 to 6.41.0 (#169) | [dependabot](https://github.com/dependabot)
+- Update dependabot.yml (#168) | [@vreynolds](https://github.com/vreynolds)
+- Bump pmdCoreVersion from 6.39.0 to 6.40.0 (#163) | [dependabot](https://github.com/dependabot)
+- Bump mockito-core from 4.0.0 to 4.1.0 (#167) | [dependabot](https://github.com/dependabot)
+- Bump spotbugs-maven-plugin from 4.4.2.1 to 4.5.0.0 (#166) | [dependabot](https://github.com/dependabot)
+- empower apply-labels action to apply labels (#164) | [Robb Kidd](https://github.com/)
+- ci: add java 17 to test matrix (#161) | [@vreynolds](https://github.com/vreynolds)
+- Bump mockito-core from 3.12.4 to 4.0.0 (#159) | [dependabot](https://github.com/dependabot)
+- Bump spotbugs-maven-plugin from 4.4.1 to 4.4.2.1 (#160) | [dependabot](https://github.com/dependabot)
+- Bump pmdCoreVersion from 6.38.0 to 6.39.0 (#156) | [dependabot](https://github.com/dependabot)
+- ci: fix meven release (#158) | [@vreynolds](https://github.com/vreynolds)
+
 ## [1.6.1] - 2021-09-27
 
 ### Added

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -1,5 +1,5 @@
 # Creating a new release
 
-1. Update the <version> tag in each pom.xml in the repo. Add new release notes to the Changelog. Open a PR with those changes.
+1. Update the <version> and <beelineVersion> tags in each pom.xml in the repo. Add new release notes to the Changelog. Open a PR with those changes.
 2. Once the above PR is merged, tag `main` with the new version, e.g. `v0.1.1`. Push the tags. This will kick off a CI workflow, which will publish a draft GitHub release, and publish artifacts to Maven.
 3. Update Release Notes on the new draft GitHub release, and publish that.

--- a/beeline-core/pom.xml
+++ b/beeline-core/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>io.honeycomb.beeline</groupId>
         <artifactId>beeline-parent</artifactId>
-        <version>1.6.1</version>
+        <version>1.7.0</version>
     </parent>
 
     <name>Beeline Java (Core)</name>

--- a/beeline-spring-boot-sleuth-starter/pom.xml
+++ b/beeline-spring-boot-sleuth-starter/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>io.honeycomb.beeline</groupId>
         <artifactId>beeline-parent</artifactId>
-        <version>1.6.1</version>
+        <version>1.7.0</version>
     </parent>
 
     <name>Beeline Java (Spring Boot Sleuth Starter)</name>
@@ -16,7 +16,7 @@
     <description>Spring Boot Sleuth Starter module to auto-configure Spring Boot Sleuth to send trace data via Honeycomb Beeline for Java</description>
 
     <properties>
-        <beelineVersion>1.5.0</beelineVersion>
+        <beelineVersion>1.7.0</beelineVersion>
     </properties>
 
     <build>

--- a/beeline-spring-boot-starter/pom.xml
+++ b/beeline-spring-boot-starter/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>io.honeycomb.beeline</groupId>
         <artifactId>beeline-parent</artifactId>
-        <version>1.6.1</version>
+        <version>1.7.0</version>
     </parent>
 
     <name>Beeline Java (Spring Boot Starter)</name>
@@ -16,7 +16,7 @@
     <description>Spring Boot Starter module to auto-configure Spring Boot with the Honeycomb Beeline for Java</description>
 
     <properties>
-        <beelineVersion>1.5.0</beelineVersion>
+        <beelineVersion>1.7.0</beelineVersion>
     </properties>
 
     <build>

--- a/pom.xml
+++ b/pom.xml
@@ -7,7 +7,7 @@
     <name>Beeline Java (Parent)</name>
     <artifactId>beeline-parent</artifactId>
     <groupId>io.honeycomb.beeline</groupId>
-    <version>1.6.1</version>
+    <version>1.7.0</version>
     <packaging>pom</packaging>
 
     <description>Parent POM for the Honeycomb Beeline for Java</description>


### PR DESCRIPTION
## Short description of the changes

- Version bump and changelog update.
- Update to RELEASING to update the `beelineVersion` tag in springy POMs, too.

