### PR TITLE
dial version back to one already published

### DIFF
--- a/RELEASING.md
+++ b/RELEASING.md
@@ -1,5 +1,5 @@
 # Creating a new release
 
-1. Update the <version> and <beelineVersion> tags in each pom.xml in the repo. Add new release notes to the Changelog. Open a PR with those changes.
+1. Update the <version> tag in each pom.xml in the repo. Add new release notes to the Changelog. Open a PR with those changes.
 2. Once the above PR is merged, tag `main` with the new version, e.g. `v0.1.1`. Push the tags. This will kick off a CI workflow, which will publish a draft GitHub release, and publish artifacts to Maven.
 3. Update Release Notes on the new draft GitHub release, and publish that.

--- a/beeline-spring-boot-sleuth-starter/pom.xml
+++ b/beeline-spring-boot-sleuth-starter/pom.xml
@@ -16,7 +16,7 @@
     <description>Spring Boot Sleuth Starter module to auto-configure Spring Boot Sleuth to send trace data via Honeycomb Beeline for Java</description>
 
     <properties>
-        <beelineVersion>1.7.0</beelineVersion>
+        <beelineVersion>1.6.1</beelineVersion>
     </properties>
 
     <build>

--- a/beeline-spring-boot-starter/pom.xml
+++ b/beeline-spring-boot-starter/pom.xml
@@ -16,7 +16,7 @@
     <description>Spring Boot Starter module to auto-configure Spring Boot with the Honeycomb Beeline for Java</description>
 
     <properties>
-        <beelineVersion>1.7.0</beelineVersion>
+        <beelineVersion>1.6.1</beelineVersion>
     </properties>
 
     <build>


### PR DESCRIPTION
## Which problem is this PR solving?

Publishing the spring-boot artifacts fails if these reference a version that isn't already published. A future todo: [resolve publishing these versions together](https://github.com/honeycombio/beeline-java/issues/173).

This merge commit will get retagged as the v1.7.0 release.
