### PR TITLE
maint: update releasing.md for current temporary issue

### DIFF
--- a/RELEASING.md
+++ b/RELEASING.md
@@ -1,5 +1,7 @@
 # Creating a new release
 
-1. Update the <version> tag in each pom.xml in the repo. Add new release notes to the Changelog. Open a PR with those changes.
-2. Once the above PR is merged, tag `main` with the new version, e.g. `v0.1.1`. Push the tags. This will kick off a CI workflow, which will publish a draft GitHub release, and publish artifacts to Maven.
-3. Update Release Notes on the new draft GitHub release, and publish that.
+1. Update the `<version>` tag in each pom.xml in the repo. **temp note**: until issue [#173](https://github.com/honeycombio/beeline-java/issues/173) is resolved, ensure the `beelineVersion` is at least one version behind the main project version.
+2. Add new release notes to the Changelog.
+3. Open a PR with those changes.
+4. Once the above PR is merged, tag `main` with the new version, e.g. `v0.1.1`. Push the tags. This will kick off a CI workflow, which will publish a draft GitHub release, and publish artifacts to Maven.
+5. Update Release Notes on the new draft GitHub release, and publish that.


### PR DESCRIPTION
<!--
Thank you for contributing to the project! 💜
Please make sure to:
- Chat with us first if this is a big change
  - Open a new issue (or comment on an existing one)
  - We want to make sure you don't spend time implementing something we might have to say No to
- Add unit tests
- Mention any relevant issues in the PR description (e.g. "Fixes #123")

Please see our [OSS process document](https://github.com/honeycombio/home/blob/main/honeycomb-oss-lifecycle-and-practices.md#) to get an idea of how we operate.
-->

## Which problem is this PR solving?

- As referenced in issue #173 the beeline cannot be published with submodules depending on the same version. This note/change in release process helps ensure the beeline publish process is successful until that issue is resolved.

## Short description of the changes

- Add temporary note into `RELEASING.md` to _not_ update `beelineVersion` until the issue is resolved (getting a newer maven dependency plugin in the orb and subsequently upgrading the orb version in circleci config)

