### PR TITLE
maint: update maven orb to handle multi-module project

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,7 +1,7 @@
 version: 2.1
 
 orbs:
-  maven: circleci/maven@1.0.3
+  maven: circleci/maven@1.3.0
 
 commands:
   with_cache:


### PR DESCRIPTION
<!--
Thank you for contributing to the project! 💜
Please make sure to:
- Chat with us first if this is a big change
  - Open a new issue (or comment on an existing one)
  - We want to make sure you don't spend time implementing something we might have to say No to
- Add unit tests
- Mention any relevant issues in the PR description (e.g. "Fixes #123")

Please see our [OSS process document](https://github.com/honeycombio/home/blob/main/honeycomb-oss-lifecycle-and-practices.md#) to get an idea of how we operate.
-->

## Which problem is this PR solving?

- closes #173 

## Short description of the changes

- upgrade maven orb in circle config, which includes newer `maven-dependency-plugin:3.1.2` instead of the default 2.8. This plugin includes a [fix for resolving artifacts](https://issues.apache.org/jira/browse/MDEP-204) that should be available as intermodule dependencies.

