### PR TITLE
Add support for Environment & Services

### DIFF
--- a/beeline-core/src/main/java/io/honeycomb/beeline/tracing/Beeline.java
+++ b/beeline-core/src/main/java/io/honeycomb/beeline/tracing/Beeline.java
@@ -169,6 +169,29 @@ public class Beeline {
 		}
     }
 
+    /**
+     * A convenience method that starts a trace.
+     * <p>
+     * Typically this would be invoked when a service receives an external request, but before the request is
+     * processed by the service. For example in an HTTP Servlet filter before
+     * {@code javax.servlet.FilterChain#doFilter(ServletRequest, ServletResponse)}} is invoked.
+     * <p>
+     * The {@code parentContext} contains information that is needed to continue traces across process boundaries, e.g.
+     * whether the external service making the request was also traced. If the external service was also traced, the
+     * span returned by this method will:
+     * <p>
+     * - share the same trace ID <br>
+     * - be the child of the span that represents the call to this service
+     * <p>
+     * The returned span is also accessible via {@link #getActiveSpan()} because it becomes the current span.
+     *
+     * @param spanName the name of the span to create
+     * @param parentContext the parent context containing inter-process tracing information
+     * @return the new current span
+     * @see Tracer#startTrace(Span)
+     * @see io.honeycomb.beeline.tracing.propagation.HttpServerPropagator#startPropagation(HttpServerRequestAdapter) for
+     * an existing solution for starting (and closing) traces for incoming requests to an HTTP server.
+     */
     public Span startTrace(final String spanName, final PropagationContext parentContext) {
         return startTrace(spanName, parentContext, serviceName);
     }

--- a/beeline-core/src/main/java/io/honeycomb/beeline/tracing/Beeline.java
+++ b/beeline-core/src/main/java/io/honeycomb/beeline/tracing/Beeline.java
@@ -1,5 +1,7 @@
 package io.honeycomb.beeline.tracing;
 
+import java.io.File;
+
 import io.honeycomb.beeline.tracing.propagation.HttpServerRequestAdapter;
 import io.honeycomb.beeline.tracing.propagation.Propagation;
 import io.honeycomb.beeline.tracing.propagation.PropagationContext;
@@ -89,8 +91,22 @@ public class Beeline {
 
     public static String resolveServiceName(String serviceName) {
         if (ObjectUtils.isNullOrEmpty(serviceName)) {
-            // TODO: figure out how to get exe / jar name as suffix
-            return String.join(":", defaultServiceName, defualtProcessName);
+            String processName;
+            try {
+                // tries to find the exe or jar path - Stack Overflow:
+                // https://stackoverflow.com/questions/28192194/how-to-get-the-path-and-name-of-the-current-running-jar
+                File dir = new File(Beeline.class.getProtectionDomain().getCodeSource().getLocation().toURI());
+                StackTraceElement[] stack = Thread.currentThread().getStackTrace();
+                StackTraceElement main = stack[stack.length - 1];
+                String mainClass = main.getClassName();
+                File f = new File(dir, mainClass);
+                processName = f.getName();
+            } catch (RuntimeException e) {
+                throw e;
+            } catch (Exception e) {
+                processName = defaultServiceName;
+            }
+            return String.join(":", defaultServiceName, processName);
         }
         return serviceName;
     }

--- a/beeline-core/src/main/java/io/honeycomb/beeline/tracing/Beeline.java
+++ b/beeline-core/src/main/java/io/honeycomb/beeline/tracing/Beeline.java
@@ -7,8 +7,7 @@ import io.honeycomb.beeline.tracing.sampling.DeterministicTraceSampler;
 import io.honeycomb.beeline.tracing.sampling.Sampling;
 import io.honeycomb.beeline.tracing.utils.TraceFieldConstants;
 import io.honeycomb.libhoney.utils.Assert;
-
-import java.util.ArrayList;
+import io.honeycomb.libhoney.utils.ObjectUtils;
 
 /**
  * The Beeline class is the main/most-convenient point of interaction with traces in a Beeline-instrumented application.
@@ -70,13 +69,30 @@ import java.util.ArrayList;
 public class Beeline {
     private final Tracer tracer;
     private final SpanBuilderFactory factory;
+    private final String serviceName;
+
+    public static final String defaultServiceName = "unknown_service";
+    public static final String defualtProcessName = "java";
 
     public Beeline(final Tracer tracer, final SpanBuilderFactory factory) {
+        this(tracer, factory, null);
+    }
+
+    public Beeline(final Tracer tracer, final SpanBuilderFactory factory, final String serviceName) {
         Assert.notNull(tracer, "Validation failed: tracer must not be null or empty");
         Assert.notNull(factory, "Validation failed: factory must not be null or empty");
 
         this.tracer = tracer;
         this.factory = factory;
+        this.serviceName = resolveServiceName(serviceName);
+    }
+
+    public static String resolveServiceName(String serviceName) {
+        if (ObjectUtils.isNullOrEmpty(serviceName)) {
+            // TODO: figure out how to get exe / jar name as suffix
+            return String.join(":", defaultServiceName, defualtProcessName);
+        }
+        return serviceName;
     }
 
     /**
@@ -153,6 +169,10 @@ public class Beeline {
 		}
     }
 
+    public Span startTrace(final String spanName, final PropagationContext parentContext) {
+        return startTrace(spanName, parentContext, serviceName);
+    }
+
     /**
      * A convenience method that starts a trace.
      * <p>
@@ -194,6 +214,10 @@ public class Beeline {
 
     public SpanBuilderFactory getSpanBuilderFactory() {
         return factory;
+    }
+
+    public String getServiceName() {
+        return serviceName;
     }
 
     /**

--- a/beeline-core/src/main/java/io/honeycomb/beeline/tracing/Tracing.java
+++ b/beeline-core/src/main/java/io/honeycomb/beeline/tracing/Tracing.java
@@ -34,7 +34,11 @@ public final class Tracing {
      * @return an instance of Beeline.
      */
     public static Beeline createBeeline(final Tracer tracer, final SpanBuilderFactory factory) {
-        return new Beeline(tracer, factory);
+        return createBeeline(tracer, factory, null);
+    }
+
+    public static Beeline createBeeline(final Tracer tracer, final SpanBuilderFactory factory, String serviceName) {
+        return new Beeline(tracer, factory, serviceName);
     }
 
     /**

--- a/beeline-core/src/main/java/io/honeycomb/beeline/tracing/propagation/HttpHeaderV1PropagationCodec.java
+++ b/beeline-core/src/main/java/io/honeycomb/beeline/tracing/propagation/HttpHeaderV1PropagationCodec.java
@@ -88,6 +88,8 @@ public class HttpHeaderV1PropagationCodec implements PropagationCodec<Map<String
      * <p>
      * Trace_id and parent_id are required to create a non-empty Propagation context, while dataset and context are
      * treated as optional.
+     * 
+     * NOTE: This codec no longer encodes or decodes dataset from the trace header.
      *
      * @param encodedTrace to decode into a {@link PropagationContext}.
      * @return extracted context - "empty" context if encodedTrace value has an invalid format or is null.
@@ -114,7 +116,6 @@ public class HttpHeaderV1PropagationCodec implements PropagationCodec<Map<String
         }
         String traceId = null;
         String parentSpanId = null;
-        String dataset = null;
         Map<String, Object> traceFields = null;
         for (final String keyValue : payloadEntries) {
             final String[] keyAndValue = SPLIT_KV.split(keyValue, 2);
@@ -140,7 +141,7 @@ public class HttpHeaderV1PropagationCodec implements PropagationCodec<Map<String
             LOG.warn("Invalid honeycomb trace header - missing IDs: {}", encodedTrace);
             return PropagationContext.emptyContext();
         }
-        return new PropagationContext(traceId, parentSpanId, dataset, traceFields);
+        return new PropagationContext(traceId, parentSpanId, null, traceFields);
     }
 
     private String encodeContext(final Map<String, Object> traceFields) {
@@ -211,10 +212,6 @@ public class HttpHeaderV1PropagationCodec implements PropagationCodec<Map<String
             (contextAsB64 == null ?
                 0 :
                 (payloadSepLength + CONTEXT_KEY.length() + kvSepLength + contextAsB64.length())
-            ) +
-            (context.getDataset() == null ?
-                0 :
-                (payloadSepLength + DATASET_KEY.length() + kvSepLength + context.getDataset().length())
             );
     }
 

--- a/beeline-core/src/main/java/io/honeycomb/beeline/tracing/propagation/HttpHeaderV1PropagationCodec.java
+++ b/beeline-core/src/main/java/io/honeycomb/beeline/tracing/propagation/HttpHeaderV1PropagationCodec.java
@@ -126,7 +126,7 @@ public class HttpHeaderV1PropagationCodec implements PropagationCodec<Map<String
                     parentSpanId = keyAndValue[1];
                     break;
                 case DATASET_KEY:
-                    dataset = decodeDataset(keyAndValue[1]);
+                    // ignore dataset
                     break;
                 case CONTEXT_KEY:
                     traceFields = decodeFields(keyAndValue[1]);
@@ -225,32 +225,11 @@ public class HttpHeaderV1PropagationCodec implements PropagationCodec<Map<String
             .append(TRACE_CONTEXT_VERSION_ONE).append(VERSION_PAYLOAD_SEPARATOR)
             .append(TRACE_ID_KEY) .append(KV_SEPARATOR).append(context.getTraceId()).append(PAYLOAD_SEPARATOR)
             .append(PARENT_ID_KEY).append(KV_SEPARATOR).append(context.getSpanId());
-        final String dataset = context.getDataset();
-        if (dataset != null) {
-            final String encodedDataset = encodeDataset(dataset);
-            stringBuilder.append(PAYLOAD_SEPARATOR).append(DATASET_KEY).append(KV_SEPARATOR).append(encodedDataset);
-        }
         if (contextAsB64 != null) {
             stringBuilder.append(PAYLOAD_SEPARATOR).append(CONTEXT_KEY).append(KV_SEPARATOR).append(contextAsB64);
         }
         return stringBuilder;
         // @formatter:on
-    }
-
-    private String encodeDataset(final String dataset) {
-        try {
-            return URLEncoder.encode(dataset, StandardCharsets.UTF_8.name());
-        } catch (final UnsupportedEncodingException e) { // very unlikely to happen!
-            throw new IllegalStateException("UTF-8 no supported", e);
-        }
-    }
-
-    private String decodeDataset(final String dataset) {
-        try {
-            return URLDecoder.decode(dataset, StandardCharsets.UTF_8.name());
-        } catch (final UnsupportedEncodingException e) { // very unlikely to happen!
-            throw new IllegalStateException("UTF-8 no supported", e);
-        }
     }
 
     public static class DefaultJsonConverter

--- a/beeline-core/src/main/java/io/honeycomb/beeline/tracing/propagation/W3CPropagationCodec.java
+++ b/beeline-core/src/main/java/io/honeycomb/beeline/tracing/propagation/W3CPropagationCodec.java
@@ -134,7 +134,7 @@ public class W3CPropagationCodec implements PropagationCodec<Map<String, String>
                     for (String kvp : decodedState.split(TRACESTATE_VENDOR_SEPARATOR)) {
                         String[] parts = kvp.split(TRACESTATE_VALUE_SEPARATOR);
                         if (parts[0].equals(DATASET_STRING)) {
-                            dataset = parts[1];
+                            // don't add dataset
                         } else {
                             if (fields == null) {
                                 fields = new HashMap<>();
@@ -184,12 +184,6 @@ public class W3CPropagationCodec implements PropagationCodec<Map<String, String>
 
         final boolean[] first = {true}; // trick for allowing scoped variables to be accessed inside lambda functions
         final StringBuilder builder = new StringBuilder();
-
-        // If not null, add dataset first
-        if (context.getDataset() != null && !context.getDataset().isEmpty()) {
-            builder.append(String.join(TRACESTATE_VALUE_SEPARATOR, DATASET_STRING, context.getDataset()));
-            first[0] = false;
-        }
 
         // Sort the fields by key and append
         context.getTraceFields().entrySet().stream()

--- a/beeline-core/src/main/java/io/honeycomb/beeline/tracing/propagation/W3CPropagationCodec.java
+++ b/beeline-core/src/main/java/io/honeycomb/beeline/tracing/propagation/W3CPropagationCodec.java
@@ -115,8 +115,7 @@ public class W3CPropagationCodec implements PropagationCodec<Map<String, String>
             return PropagationContext.emptyContext();
         }
 
-        // try to parse dataset and other trace fields from tracestate header
-        String dataset = null;
+        // try to parse trace fields from tracestate header
         Map<String, String> fields = null;
         String encodedState = headers.get(W3C_TRACESTATE_HEADER);
         if (encodedState != null) {
@@ -134,7 +133,7 @@ public class W3CPropagationCodec implements PropagationCodec<Map<String, String>
                     for (String kvp : decodedState.split(TRACESTATE_VENDOR_SEPARATOR)) {
                         String[] parts = kvp.split(TRACESTATE_VALUE_SEPARATOR);
                         if (parts[0].equals(DATASET_STRING)) {
-                            // don't add dataset
+                            // don't use dataset
                         } else {
                             if (fields == null) {
                                 fields = new HashMap<>();
@@ -146,7 +145,7 @@ public class W3CPropagationCodec implements PropagationCodec<Map<String, String>
             }
         }
 
-        return new PropagationContext(segments[1], segments[2], dataset, fields);
+        return new PropagationContext(segments[1], segments[2], null, fields);
     }
 
     /**
@@ -175,8 +174,8 @@ public class W3CPropagationCodec implements PropagationCodec<Map<String, String>
 
         final String traceParent = String.join(SEGMENT_SEPARATOR, DEFAULT_VERSION, context.getTraceId(), context.getSpanId(), SAMPLED_TRACEFLAGS);
 
-        // If no dataset or tracefields, just return trace parent header
-        if (context.getDataset() == null && context.getTraceFields().isEmpty()) {
+        // If no tracefields, just return trace parent header
+        if (context.getTraceFields().isEmpty()) {
             return Optional.of(
                 Collections.singletonMap(W3C_TRACEPARENT_HEADER, traceParent)
             );

--- a/beeline-core/src/test/java/io/honeycomb/beeline/builder/BeelineBuilderTest.java
+++ b/beeline-core/src/test/java/io/honeycomb/beeline/builder/BeelineBuilderTest.java
@@ -30,6 +30,9 @@ import static org.mockito.Mockito.when;
 @RunWith(MockitoJUnitRunner.class)
 public class BeelineBuilderTest {
 
+    private static final String classicWriteKey = "e38be416d0d68f9ed1e96432ac1a3380";
+    private static final String nonClassicWriteKey = "d68f9ed1e96432ac1a3380";
+
     BeelineBuilder builder;
     HoneyClientBuilder mockBuilder;
     @Before
@@ -81,9 +84,9 @@ public class BeelineBuilderTest {
 
     @Test
     public void writeKey() {
-        final Beeline beeline = builder.writeKey("key").build();
-        verify(mockBuilder, times(1)).writeKey("key");
-        verify(mockBuilder, times(1)).dataSet("unknown_service");
+        final Beeline beeline = builder.writeKey(classicWriteKey).build();
+        verify(mockBuilder, times(1)).writeKey(classicWriteKey);
+        verify(mockBuilder, times(1)).dataSet("beeline-java");
         completeNegativeVerification();
     }
 
@@ -259,7 +262,7 @@ public class BeelineBuilderTest {
     }
 
     @Test
-    public void defaultDatasetClassic() {
+    public void noWriteKeyGetsDefaultClassicDataset() {
         final Beeline beeline = builder.build();
 
         assertThat(beeline.getServiceName()).isEqualTo("unknown_service:java");
@@ -268,12 +271,58 @@ public class BeelineBuilderTest {
     }
 
     @Test
-    public void defaultDatasetNonClassic() {
-        final Beeline beeline = builder.writeKey("non-classic").build();
+    public void emptyWriteKeyGetsDefaultClassicDataset() {
+        final Beeline beeline = builder.writeKey("").build();
 
         assertThat(beeline.getServiceName()).isEqualTo("unknown_service:java");
-        verify(mockBuilder, times(1)).writeKey("non-classic");
+        verify(mockBuilder, times(1)).dataSet("beeline-java");
+        completeNegativeVerification();
+    }
+
+    @Test
+    public void classicWriteKeyGetsDefaultClassicDataset() {
+        final Beeline beeline = builder.writeKey(classicWriteKey).build();
+
+        assertThat(beeline.getServiceName()).isEqualTo("unknown_service:java");
+        verify(mockBuilder, times(1)).writeKey(classicWriteKey);
+        verify(mockBuilder, times(1)).dataSet("beeline-java");
+        completeNegativeVerification();
+    }
+
+    @Test
+    public void modernWriteKeyGetsDefaultNonClassicDataset() {
+        final Beeline beeline = builder.writeKey(nonClassicWriteKey).build();
+
+        assertThat(beeline.getServiceName()).isEqualTo("unknown_service:java");
+        verify(mockBuilder, times(1)).writeKey(nonClassicWriteKey);
         verify(mockBuilder, times(1)).dataSet("unknown_service");
+        completeNegativeVerification();
+    }
+
+    @Test
+    public void writeKeyDatasetAndServiceNameAreTrimmedOfWhiteSpace() {
+        final Beeline beeline = builder
+            .writeKey(" " + classicWriteKey + " ")
+            .dataSet(" my-dataset ")
+            .serviceName(" my-service ")
+            .build();
+
+        assertThat(beeline.getServiceName()).isEqualTo("my-service");
+        verify(mockBuilder, times(1)).writeKey(classicWriteKey);
+        verify(mockBuilder, times(1)).dataSet("my-dataset");
+        completeNegativeVerification();
+    }
+
+    @Test
+    public void emptyServiceNameGetsDefaultServiceName() {
+        final Beeline beeline = builder
+            .writeKey(classicWriteKey)
+            .serviceName("")
+            .build();
+
+        assertThat(beeline.getServiceName()).isEqualTo("unknown_service:java");
+        verify(mockBuilder, times(1)).writeKey(classicWriteKey);
+        verify(mockBuilder, times(1)).dataSet("beeline-java");
         completeNegativeVerification();
     }
 

--- a/beeline-core/src/test/java/io/honeycomb/beeline/builder/BeelineBuilderTest.java
+++ b/beeline-core/src/test/java/io/honeycomb/beeline/builder/BeelineBuilderTest.java
@@ -265,7 +265,7 @@ public class BeelineBuilderTest {
     public void noWriteKeyGetsDefaultClassicDataset() {
         final Beeline beeline = builder.build();
 
-        assertThat(beeline.getServiceName()).isEqualTo("unknown_service:java");
+        assertThat(beeline.getServiceName()).isEqualTo(Beeline.resolveServiceName(""));
         verify(mockBuilder, times(1)).dataSet("beeline-java");
         completeNegativeVerification();
     }
@@ -274,7 +274,7 @@ public class BeelineBuilderTest {
     public void emptyWriteKeyGetsDefaultClassicDataset() {
         final Beeline beeline = builder.writeKey("").build();
 
-        assertThat(beeline.getServiceName()).isEqualTo("unknown_service:java");
+        assertThat(beeline.getServiceName()).isEqualTo(Beeline.resolveServiceName(""));
         verify(mockBuilder, times(1)).dataSet("beeline-java");
         completeNegativeVerification();
     }
@@ -283,7 +283,7 @@ public class BeelineBuilderTest {
     public void classicWriteKeyGetsDefaultClassicDataset() {
         final Beeline beeline = builder.writeKey(classicWriteKey).build();
 
-        assertThat(beeline.getServiceName()).isEqualTo("unknown_service:java");
+        assertThat(beeline.getServiceName()).isEqualTo(Beeline.resolveServiceName(""));
         verify(mockBuilder, times(1)).writeKey(classicWriteKey);
         verify(mockBuilder, times(1)).dataSet("beeline-java");
         completeNegativeVerification();
@@ -293,7 +293,7 @@ public class BeelineBuilderTest {
     public void modernWriteKeyGetsDefaultNonClassicDataset() {
         final Beeline beeline = builder.writeKey(nonClassicWriteKey).build();
 
-        assertThat(beeline.getServiceName()).isEqualTo("unknown_service:java");
+        assertThat(beeline.getServiceName()).isEqualTo(Beeline.resolveServiceName(""));
         verify(mockBuilder, times(1)).writeKey(nonClassicWriteKey);
         verify(mockBuilder, times(1)).dataSet("unknown_service");
         completeNegativeVerification();
@@ -320,7 +320,7 @@ public class BeelineBuilderTest {
             .serviceName("")
             .build();
 
-        assertThat(beeline.getServiceName()).isEqualTo("unknown_service:java");
+        assertThat(beeline.getServiceName()).startsWith(Beeline.resolveServiceName(""));
         verify(mockBuilder, times(1)).writeKey(classicWriteKey);
         verify(mockBuilder, times(1)).dataSet("beeline-java");
         completeNegativeVerification();

--- a/beeline-core/src/test/java/io/honeycomb/beeline/builder/BeelineBuilderTest.java
+++ b/beeline-core/src/test/java/io/honeycomb/beeline/builder/BeelineBuilderTest.java
@@ -16,6 +16,7 @@ import javax.net.ssl.SSLContext;
 import java.net.URI;
 import java.net.URISyntaxException;
 
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.ArgumentMatchers.eq;
@@ -42,6 +43,7 @@ public class BeelineBuilderTest {
     public void addGlobalField() {
         final Beeline beeline = builder.addGlobalField("name", "value").build();
         verify(mockBuilder, times(1)).addGlobalField("name", "value");
+        verify(mockBuilder, times(1)).dataSet("beeline-java");
         completeNegativeVerification();
     }
 
@@ -49,6 +51,7 @@ public class BeelineBuilderTest {
     public void addGlobalDynamicFields() {
         final Beeline beeline = builder.addGlobalDynamicFields("name", mock(ValueSupplier.class)).build();
         verify(mockBuilder, times(1)).addGlobalDynamicFields(eq("name"), any(ValueSupplier.class));
+        verify(mockBuilder, times(1)).dataSet("beeline-java");
         completeNegativeVerification();
     }
 
@@ -56,6 +59,7 @@ public class BeelineBuilderTest {
     public void addProxyCredential() {
         final Beeline beeline = builder.addProxy("proxy.domain.com:8443", "user", "secret").build();
         verify(mockBuilder, times(1)).addProxy("proxy.domain.com:8443", "user", "secret");
+        verify(mockBuilder, times(1)).dataSet("beeline-java");
         completeNegativeVerification();
     }
 
@@ -71,6 +75,7 @@ public class BeelineBuilderTest {
         final Beeline beeline = builder.apiHost("host:80").build();
         verify(mockBuilder, times(1)).apiHost("host:80");
         verify(mockBuilder, times(1)).apiHost(any(URI.class));
+        verify(mockBuilder, times(1)).dataSet("beeline-java");
         completeNegativeVerification();
     }
 
@@ -78,6 +83,7 @@ public class BeelineBuilderTest {
     public void writeKey() {
         final Beeline beeline = builder.writeKey("key").build();
         verify(mockBuilder, times(1)).writeKey("key");
+        verify(mockBuilder, times(1)).dataSet("unknown_service");
         completeNegativeVerification();
     }
 
@@ -85,12 +91,14 @@ public class BeelineBuilderTest {
     public void testDebugEnabled() {
         final Beeline beeline = builder.debug(true).build();
         verify(mockBuilder, times(1)).debug(true);
+        verify(mockBuilder, times(1)).dataSet("beeline-java");
         completeNegativeVerification();
     }
     @Test
     public void testDebugDisabled() {
         final Beeline beeline = builder.debug(false).build();
         verify(mockBuilder, times(1)).debug(false);
+        verify(mockBuilder, times(1)).dataSet("beeline-java");
         completeNegativeVerification();
     }
 
@@ -98,6 +106,7 @@ public class BeelineBuilderTest {
     public void sampleRate() {
         final Beeline beeline = builder.sampleRate(123).build();
         verify(mockBuilder, times(1)).sampleRate(123);
+        verify(mockBuilder, times(1)).dataSet("beeline-java");
         completeNegativeVerification();
     }
 
@@ -105,6 +114,7 @@ public class BeelineBuilderTest {
     public void batchSize() {
         final Beeline beeline = builder.batchSize(123).build();
         verify(mockBuilder, times(1)).batchSize(123);
+        verify(mockBuilder, times(1)).dataSet("beeline-java");
         completeNegativeVerification();
     }
 
@@ -112,6 +122,7 @@ public class BeelineBuilderTest {
     public void batchTimeoutMillis() {
         final Beeline beeline = builder.batchTimeoutMillis(123).build();
         verify(mockBuilder, times(1)).batchTimeoutMillis(123);
+        verify(mockBuilder, times(1)).dataSet("beeline-java");
         completeNegativeVerification();
     }
 
@@ -119,6 +130,7 @@ public class BeelineBuilderTest {
     public void queueCapacity() {
         builder.queueCapacity(123).build();
         verify(mockBuilder, times(1)).queueCapacity(123);
+        verify(mockBuilder, times(1)).dataSet("beeline-java");
         completeNegativeVerification();
     }
 
@@ -126,6 +138,7 @@ public class BeelineBuilderTest {
     public void maxPendingBatchRequests() {
         builder.maxPendingBatchRequests(123).build();
         verify(mockBuilder, times(1)).maxPendingBatchRequests(123);
+        verify(mockBuilder, times(1)).dataSet("beeline-java");
         completeNegativeVerification();
     }
 
@@ -133,6 +146,7 @@ public class BeelineBuilderTest {
     public void maxConnections() {
         builder.maxConnections(123).build();
         verify(mockBuilder, times(1)).maxConnections(123);
+        verify(mockBuilder, times(1)).dataSet("beeline-java");
         completeNegativeVerification();
     }
 
@@ -140,6 +154,7 @@ public class BeelineBuilderTest {
     public void maxConnectionsPerApiHost() {
         builder.maxConnectionsPerApiHost(123).build();
         verify(mockBuilder, times(1)).maxConnectionsPerApiHost(123);
+        verify(mockBuilder, times(1)).dataSet("beeline-java");
         completeNegativeVerification();
     }
 
@@ -147,6 +162,7 @@ public class BeelineBuilderTest {
     public void connectionTimeout() {
         final Beeline beeline = builder.connectionTimeout(123).build();
         verify(mockBuilder, times(1)).connectionTimeout(123);
+        verify(mockBuilder, times(1)).dataSet("beeline-java");
         completeNegativeVerification();
     }
 
@@ -154,6 +170,7 @@ public class BeelineBuilderTest {
     public void connectionRequestTimeout() {
         builder.connectionRequestTimeout(123).build();
         verify(mockBuilder, times(1)).connectionRequestTimeout(123);
+        verify(mockBuilder, times(1)).dataSet("beeline-java");
         completeNegativeVerification();
     }
 
@@ -161,6 +178,7 @@ public class BeelineBuilderTest {
     public void socketTimeout() {
         builder.socketTimeout(123).build();
         verify(mockBuilder, times(1)).socketTimeout(123);
+        verify(mockBuilder, times(1)).dataSet("beeline-java");
         completeNegativeVerification();
     }
 
@@ -168,6 +186,7 @@ public class BeelineBuilderTest {
     public void bufferSize() {
         builder.bufferSize(5_000).build();
         verify(mockBuilder, times(1)).bufferSize(5_000);
+        verify(mockBuilder, times(1)).dataSet("beeline-java");
         completeNegativeVerification();
     }
 
@@ -175,6 +194,7 @@ public class BeelineBuilderTest {
     public void ioThreadCount() {
         builder.ioThreadCount(1).build();
         verify(mockBuilder, times(1)).ioThreadCount(1);
+        verify(mockBuilder, times(1)).dataSet("beeline-java");
         completeNegativeVerification();
     }
 
@@ -182,6 +202,7 @@ public class BeelineBuilderTest {
     public void maximumHttpRequestShutdownWait() {
         builder.maximumHttpRequestShutdownWait(345L).build();
         verify(mockBuilder, times(1)).maximumHttpRequestShutdownWait(345L);
+        verify(mockBuilder, times(1)).dataSet("beeline-java");
         completeNegativeVerification();
     }
 
@@ -189,6 +210,7 @@ public class BeelineBuilderTest {
     public void additionalUserAgent() {
         builder.additionalUserAgent("agent").build();
         verify(mockBuilder, times(1)).additionalUserAgent("agent");
+        verify(mockBuilder, times(1)).dataSet("beeline-java");
         completeNegativeVerification();
     }
 
@@ -196,6 +218,7 @@ public class BeelineBuilderTest {
     public void addProxyNoCredentials() {
         builder.addProxy("proxyHost").build();
         verify(mockBuilder, times(1)).addProxy(anyString());
+        verify(mockBuilder, times(1)).dataSet("beeline-java");
         completeNegativeVerification();
     }
 
@@ -204,6 +227,7 @@ public class BeelineBuilderTest {
         final SSLContext mockContext = mock(SSLContext.class);
         builder.sslContext(mockContext).build();
         verify(mockBuilder, times(1)).sslContext(any(SSLContext.class));
+        verify(mockBuilder, times(1)).dataSet("beeline-java");
         completeNegativeVerification();
     }
 
@@ -211,6 +235,7 @@ public class BeelineBuilderTest {
     public void addResponseObserver() {
         builder.addResponseObserver(mock(ResponseObserver.class)).build();
         verify(mockBuilder, times(1)).addResponseObserver(any(ResponseObserver.class));
+        verify(mockBuilder, times(1)).dataSet("beeline-java");
         completeNegativeVerification();
     }
 
@@ -218,6 +243,7 @@ public class BeelineBuilderTest {
     public void eventPostProcessor() {
         builder.eventPostProcessor(mock(EventPostProcessor.class)).build();
         verify(mockBuilder, times(1)).eventPostProcessor(any(EventPostProcessor.class));
+        verify(mockBuilder, times(1)).dataSet("beeline-java");
         completeNegativeVerification();
     }
 
@@ -227,7 +253,27 @@ public class BeelineBuilderTest {
         final Beeline beeline = builder.transport(mockTransport).build();
 
         verify(mockBuilder, times(1)).transport(mockTransport);
+        verify(mockBuilder, times(1)).dataSet("beeline-java");
         verifyNoMoreInteractions(mockTransport);
+        completeNegativeVerification();
+    }
+
+    @Test
+    public void defaultDatasetClassic() {
+        final Beeline beeline = builder.build();
+
+        assertThat(beeline.getServiceName()).isEqualTo("unknown_service:java");
+        verify(mockBuilder, times(1)).dataSet("beeline-java");
+        completeNegativeVerification();
+    }
+
+    @Test
+    public void defaultDatasetNonClassic() {
+        final Beeline beeline = builder.writeKey("non-classic").build();
+
+        assertThat(beeline.getServiceName()).isEqualTo("unknown_service:java");
+        verify(mockBuilder, times(1)).writeKey("non-classic");
+        verify(mockBuilder, times(1)).dataSet("unknown_service");
         completeNegativeVerification();
     }
 

--- a/beeline-core/src/test/java/io/honeycomb/beeline/tracing/propagation/HttpHeaderV1PropagationCodecTest.java
+++ b/beeline-core/src/test/java/io/honeycomb/beeline/tracing/propagation/HttpHeaderV1PropagationCodecTest.java
@@ -42,7 +42,7 @@ public class HttpHeaderV1PropagationCodecTest {
 
         assertThat(decode.getSpanId()).isEqualTo("abc");
         assertThat(decode.getTraceId()).isEqualTo("123");
-        assertThat(decode.getDataset()).isEqualTo("hellodataset");
+        assertThat(decode.getDataset()).isNull();
         assertThat(decode.getTraceFields()).containsExactly(entry("test", "value"));
     }
 
@@ -56,7 +56,7 @@ public class HttpHeaderV1PropagationCodecTest {
 
         assertThat(decode.getSpanId()).isEqualTo("abc");
         assertThat(decode.getTraceId()).isEqualTo("123");
-        assertThat(decode.getDataset()).isEqualTo("hellodataset");
+        assertThat(decode.getDataset()).isNull();
         assertThat(decode.getTraceFields()).containsExactly(entry("test", "value"));
     }
 
@@ -102,7 +102,7 @@ public class HttpHeaderV1PropagationCodecTest {
 
         final PropagationContext decode = codec.decode(Collections.singletonMap(HttpHeaderV1PropagationCodec.HONEYCOMB_TRACE_HEADER, traceHeader));
 
-        assertThat(decode.getDataset()).isEqualTo("/hello world");
+        assertThat(decode.getDataset()).isNull();
     }
 
     @Test
@@ -278,7 +278,7 @@ public class HttpHeaderV1PropagationCodecTest {
         final Map<String, String> encoded = codec.encode(new PropagationContext("abc", "123", "myDataset", Collections.singletonMap("key", "value"))).get();
 
         assertThat(encoded).isEqualTo(
-            Collections.singletonMap(HttpHeaderV1PropagationCodec.HONEYCOMB_TRACE_HEADER, "1;trace_id=abc,parent_id=123,dataset=myDataset,context=" + Base64.encodeBase64String("{\"key\":\"value\"}".getBytes(UTF_8)))
+            Collections.singletonMap(HttpHeaderV1PropagationCodec.HONEYCOMB_TRACE_HEADER, "1;trace_id=abc,parent_id=123,context=" + Base64.encodeBase64String("{\"key\":\"value\"}".getBytes(UTF_8)))
         );
     }
 
@@ -287,7 +287,7 @@ public class HttpHeaderV1PropagationCodecTest {
         final Map<String, String> encoded = codec.encode(new PropagationContext("abc", "123", "/hello world", Collections.singletonMap("key", "value"))).get();
 
         assertThat(encoded).isEqualTo(
-            Collections.singletonMap(HttpHeaderV1PropagationCodec.HONEYCOMB_TRACE_HEADER, "1;trace_id=abc,parent_id=123,dataset=%2Fhello+world,context=" + Base64.encodeBase64String("{\"key\":\"value\"}".getBytes(UTF_8)))
+            Collections.singletonMap(HttpHeaderV1PropagationCodec.HONEYCOMB_TRACE_HEADER, "1;trace_id=abc,parent_id=123,context=" + Base64.encodeBase64String("{\"key\":\"value\"}".getBytes(UTF_8)))
         );
     }
 
@@ -306,7 +306,7 @@ public class HttpHeaderV1PropagationCodecTest {
         final Map<String, String> encoded = codec.encode(new PropagationContext("abc", "123", "myDataset", Collections.emptyMap())).get();
 
         assertThat(encoded).isEqualTo(
-            Collections.singletonMap(HttpHeaderV1PropagationCodec.HONEYCOMB_TRACE_HEADER, "1;trace_id=abc,parent_id=123,dataset=myDataset")
+            Collections.singletonMap(HttpHeaderV1PropagationCodec.HONEYCOMB_TRACE_HEADER, "1;trace_id=abc,parent_id=123")
         );
     }
 
@@ -315,7 +315,7 @@ public class HttpHeaderV1PropagationCodecTest {
         final Map<String, String> encoded = codec.encode(new PropagationContext("abc", "123", "myDataset", Collections.singletonMap("key", Collections.singletonMap("nested-key", "value")))).get();
 
         assertThat(encoded).isEqualTo(
-            Collections.singletonMap(HttpHeaderV1PropagationCodec.HONEYCOMB_TRACE_HEADER, "1;trace_id=abc,parent_id=123,dataset=myDataset,context=" + Base64.encodeBase64String("{\"key\":{\"nested-key\":\"value\"}}".getBytes(UTF_8)))
+            Collections.singletonMap(HttpHeaderV1PropagationCodec.HONEYCOMB_TRACE_HEADER, "1;trace_id=abc,parent_id=123,context=" + Base64.encodeBase64String("{\"key\":{\"nested-key\":\"value\"}}".getBytes(UTF_8)))
         );
     }
 
@@ -324,7 +324,7 @@ public class HttpHeaderV1PropagationCodecTest {
         final Map<String, String> encoded = codec.encode(new PropagationContext("abc", "123", "myDataset", Collections.singletonMap("key", Collections.singletonMap("nested-key", new Unserializable())))).get();
 
         assertThat(encoded).isEqualTo(
-            Collections.singletonMap(HttpHeaderV1PropagationCodec.HONEYCOMB_TRACE_HEADER, "1;trace_id=abc,parent_id=123,dataset=myDataset")
+            Collections.singletonMap(HttpHeaderV1PropagationCodec.HONEYCOMB_TRACE_HEADER, "1;trace_id=abc,parent_id=123")
         );
     }
 

--- a/beeline-core/src/test/java/io/honeycomb/beeline/tracing/propagation/W3CPropagationCodecTest.java
+++ b/beeline-core/src/test/java/io/honeycomb/beeline/tracing/propagation/W3CPropagationCodecTest.java
@@ -173,7 +173,7 @@ public class W3CPropagationCodecTest {
         assertThat(context.getTraceId()).isEqualTo("4cbc8d50f02449e887e8bc2aa8020d26");
         assertThat(context.getSpanId()).isEqualTo("ace1ecab581fc069");
         assertThat(context.getTraceFields().size()).isEqualTo(0);
-        assertThat(context.getDataset()).isEqualTo("test-dataset");
+        assertThat(context.getDataset()).isNull();
     }
 
     @Test
@@ -207,7 +207,7 @@ public class W3CPropagationCodecTest {
         assertThat(context.getSpanId()).isEqualTo("ace1ecab581fc069");
         assertThat(context.getTraceFields().size()).isEqualTo(1);
         assertThat(context.getTraceFields().get("foo")).isEqualTo("bar");
-        assertThat(context.getDataset()).isEqualTo("test-dataset");
+        assertThat(context.getDataset()).isNull();
     }
 
     @Test
@@ -224,7 +224,7 @@ public class W3CPropagationCodecTest {
         assertThat(context.getSpanId()).isEqualTo("ace1ecab581fc069");
         assertThat(context.getTraceFields().size()).isEqualTo(1);
         assertThat(context.getTraceFields().get("foo")).isEqualTo("bar");
-        assertThat(context.getDataset()).isEqualTo("test-dataset");
+        assertThat(context.getDataset()).isNull();
     }
 
     // Encode
@@ -255,7 +255,6 @@ public class W3CPropagationCodecTest {
 
         final Map<String, String> headers = new HashMap<>();
         headers.put(W3CPropagationCodec.W3C_TRACEPARENT_HEADER, String.join("-", "00", traceId, spanId, "01"));
-        headers.put(W3CPropagationCodec.W3C_TRACESTATE_HEADER, "hny=ZGF0YXNldD10ZXN0LWRhdGFzZXQ=");
 
         final Map<String, String> encoded = codec.encode(new PropagationContext(traceId, spanId, dataset, null)).get();
         assertThat(encoded).isEqualTo(headers);
@@ -288,7 +287,7 @@ public class W3CPropagationCodecTest {
 
         final Map<String, String> headers = new HashMap<>();
         headers.put(W3CPropagationCodec.W3C_TRACEPARENT_HEADER, String.join("-", "00", traceId, spanId, "01"));
-        headers.put(W3CPropagationCodec.W3C_TRACESTATE_HEADER,  "hny=ZGF0YXNldD10ZXN0LWRhdGFzZXQsZm9vPWJhcixvbmU9dHdv");
+        headers.put(W3CPropagationCodec.W3C_TRACESTATE_HEADER,  "hny=Zm9vPWJhcixvbmU9dHdv");
 
         final Map<String, String> encoded = codec.encode(new PropagationContext(traceId, spanId, dataset, fields)).get();
         assertThat(encoded).isEqualTo(headers);


### PR DESCRIPTION
<!--
Thank you for contributing to the project! 💜
Please make sure to:
- Chat with us first if this is a big change
  - Open a new issue (or comment on an existing one)
  - We want to make sure you don't spend time implementing something we might have to say No to
- Add unit tests
- Mention any relevant issues in the PR description (e.g. "Fixes #123")

Please see our [OSS process document](https://github.com/honeycombio/home/blob/main/honeycomb-oss-lifecycle-and-practices.md#) to get an idea of how we operate.
-->

## Which problem is this PR solving?
Adds E&S support by moving service name to be a beeline property updating BeelineBuilder to determine environment type from API key and use default values as appropriate.

The beeline also now assigns a default service name based on the API key provided. Classic gets "beeline-go" and non-classic gets "unknown_service:{process-name}" where process name is the exe/jar name and falls back to "java" is it cannot resolve it.

The Beeline now applies the following defaults:

| Property | Classic | Non-classic |
| - | - | - |
| service name | unknown_service:java | unknown_service:java |
| dataset | beeline-java | unknown_service |

We no longer propagate dataset in the Honeycomb or W3C propagation codecs. This is because each app should set it's own service name, and no infer the dataset from an upstream service. This makes this a major bump.

- Closes #186 

## Short description of the changes
- Move service name to be a Beeline property
- Make writekey, dataset and servicename internal fields in BeelineBuilder, then resolve according to api key type during `Build`
- Update tests and add extra tests for default service name and dataset
- Don't propagate dataset in Honeycomb or W3C propagation codecs
