### PR TITLE
feat: add service.name field in addition to service_name

### DIFF
--- a/beeline-core/src/main/java/io/honeycomb/beeline/tracing/SpanPostProcessor.java
+++ b/beeline-core/src/main/java/io/honeycomb/beeline/tracing/SpanPostProcessor.java
@@ -64,6 +64,7 @@ public class SpanPostProcessor {
         event
             .addField(TraceFieldConstants.SPAN_NAME_FIELD, span.getSpanName())
             .addField(TraceFieldConstants.SERVICE_NAME_FIELD, span.getServiceName())
+            .addField(TraceFieldConstants.SERVICE_DOT_NAME_FIELD, span.getServiceName())
             .addField(TraceFieldConstants.SPAN_ID_FIELD, span.getSpanId())
             .addField(TraceFieldConstants.TRACE_ID_FIELD, span.getTraceId());
     }

--- a/beeline-core/src/main/java/io/honeycomb/beeline/tracing/utils/TraceFieldConstants.java
+++ b/beeline-core/src/main/java/io/honeycomb/beeline/tracing/utils/TraceFieldConstants.java
@@ -23,6 +23,8 @@ public final class TraceFieldConstants {
     public static final String TYPE_FIELD                   = "type";
     /** Name of the application being instrumented. */
     public static final String SERVICE_NAME_FIELD           = "service_name";
+    /** Name of the application being instrumented. */
+    public static final String SERVICE_DOT_NAME_FIELD       = "service.name";
     /** Name of the operation the span covers. */
     public static final String SPAN_NAME_FIELD              = "name";
     /** Duration the operation took, in milliseconds (as a double). */

--- a/beeline-core/src/test/java/io/honeycomb/beeline/tracing/SendingSpanTest.java
+++ b/beeline-core/src/test/java/io/honeycomb/beeline/tracing/SendingSpanTest.java
@@ -247,6 +247,7 @@ public class SendingSpanTest {
         assertThat(event.getFields())
             .contains(
                 entry("service_name", "service1"),
+                entry("service.name", "service1"),
                 entry("name", "span1"),
                 entry("duration_ms", 700.0),
                 entry("trace.span_id", "$$$"),
@@ -271,6 +272,7 @@ public class SendingSpanTest {
         assertThat(event.getFields())
             .contains(
                 entry("service_name", "service1"),
+                entry("service.name", "service1"),
                 entry("name", "span1"),
                 entry("duration_ms", 700.0),
                 entry("trace.span_id", "$$$"),
@@ -291,6 +293,7 @@ public class SendingSpanTest {
         final ResolvedEvent event = captureSubmittedEvent(mockTransport);
 
         assertThat(event.getFields()).containsEntry("service_name", "ricotta");
+        assertThat(event.getFields()).containsEntry("service.name", "ricotta");
     }
 
     @Test

--- a/beeline-core/src/test/java/io/honeycomb/beeline/tracing/SpanPostProcessorTest.java
+++ b/beeline-core/src/test/java/io/honeycomb/beeline/tracing/SpanPostProcessorTest.java
@@ -56,6 +56,7 @@ public class SpanPostProcessorTest {
         verify(event).setDataset("myDataset");
         verify(event).setTimestamp(anyLong());
         verify(event).addField("service_name", "serviceName");
+        verify(event).addField("service.name", "serviceName");
         verify(event).addField("name", "spanName");
         verify(event).addField("trace.span_id", "spanId");
         verify(event).addField("trace.trace_id", "traceId");

--- a/beeline-core/src/test/java/io/honeycomb/beeline/tracing/TracerTest.java
+++ b/beeline-core/src/test/java/io/honeycomb/beeline/tracing/TracerTest.java
@@ -96,6 +96,7 @@ public class TracerTest {
 
         assertThatEventHasFields(of(
             "service_name", "serviceA",
+            "service.name", "serviceA",
             "name", "span1")
         );
     }
@@ -108,6 +109,7 @@ public class TracerTest {
 
         assertThatEventHasFields(of(
             "service_name", "serviceA",
+            "service.name", "serviceA",
             "name", "span1")
         );
     }
@@ -128,11 +130,13 @@ public class TracerTest {
         assertThat(capturedEvent.getWriteKey()).isEqualTo("testWriteKey");
         assertThat(eventFields).containsAllEntriesOf(of(
             "service_name", "serviceA",
+            "service.name", "serviceA",
             "name", "span1",
             "trace.span_id", rootSpan.getSpanId(),
             "trace.trace_id", rootSpan.getTraceId()
         ));
         assertThat(eventFields).containsEntry("service_name", "serviceA");
+        assertThat(eventFields).containsEntry("service.name", "serviceA");
         assertThat(eventFields).containsEntry("name", "span1");
         assertThat(eventFields).containsEntry("trace.span_id", rootSpan.getSpanId());
         assertThat(eventFields).containsEntry("trace.trace_id", rootSpan.getTraceId());
@@ -164,6 +168,7 @@ public class TracerTest {
         ));
         assertThat(eventFields).containsKey("duration_ms");
         assertThat(eventFields).doesNotContainKeys("meta.dirty_context", "meta.sent_by_parent");
+        assertThat(eventFields).containsEntry("service.name", "serviceA");
     }
 
     @Test
@@ -475,6 +480,7 @@ public class TracerTest {
 
         assertThatEventHasFields(of(
             "service_name", "serviceA",
+            "service.name", "serviceA",
             "name", "spanB")
         );
         assertThat(detachedSpan.getSpanName()).isEqualTo("detachedSpan");
@@ -488,6 +494,7 @@ public class TracerTest {
 
         assertThatEventHasFields(of(
             "service_name", "serviceA",
+            "service.name", "serviceA",
             "name", "detachedSpan")
         );
     }


### PR DESCRIPTION
<!--
Thank you for contributing to the project! 💜
Please make sure to:
- Chat with us first if this is a big change
  - Open a new issue (or comment on an existing one)
  - We want to make sure you don't spend time implementing something we might have to say No to
- Add unit tests
- Mention any relevant issues in the PR description (e.g. "Fixes #123")

Please see our [OSS process document](https://github.com/honeycombio/home/blob/main/honeycomb-oss-lifecycle-and-practices.md#) to get an idea of how we operate.
-->

## Which problem is this PR solving?

- We decided we would start adding `service.name` field for more consistency with OpenTelemetry. `service_name` continues to be sent.

## Short description of the changes

- add `service.name` field in addition to `service_name`
