### PR TITLE
fix: only trim service name for dataset

### DIFF
--- a/beeline-core/src/main/java/io/honeycomb/beeline/builder/BeelineBuilder.java
+++ b/beeline-core/src/main/java/io/honeycomb/beeline/builder/BeelineBuilder.java
@@ -82,7 +82,7 @@ public class BeelineBuilder {
                                     : serviceName.trim());
         }
 
-        if (serviceName.trim() != serviceName) {
+        if (!serviceName.trim().equals(serviceName)) {
             System.err.println("extra whitespace in service name");
         }
 

--- a/beeline-core/src/main/java/io/honeycomb/beeline/builder/BeelineBuilder.java
+++ b/beeline-core/src/main/java/io/honeycomb/beeline/builder/BeelineBuilder.java
@@ -59,7 +59,7 @@ public class BeelineBuilder {
         } else {
             clientBuilder.writeKey(writeKey);
         }
-        
+
         if (ObjectUtils.isNullOrEmpty(writeKey) || isClassic(writeKey)) {
             if (ObjectUtils.isNullOrEmpty(dataset)) {
                 System.err.println("empty dataset");
@@ -72,10 +72,18 @@ public class BeelineBuilder {
                 System.err.println("dataset should be empty - using service name instead");
             }
 
-            // use service name as dataset, ignore process suffix if using default service name
+            // use trimmed service name as dataset
+            // if trimmed service name is prefixed with unknown_service
+            // or is empty string, set dataset to unknown_service
             clientBuilder.dataSet(
-                serviceName.startsWith(Beeline.defaultServiceName) ? Beeline.defaultServiceName : serviceName
-            );
+                    serviceName.trim().startsWith(Beeline.defaultServiceName)
+                            || ObjectUtils.isNullOrEmpty(serviceName.trim())
+                                    ? Beeline.defaultServiceName
+                                    : serviceName.trim());
+        }
+
+        if (serviceName.trim() != serviceName) {
+            System.err.println("extra whitespace in service name");
         }
 
         return createBeeline(clientBuilder.build());
@@ -170,11 +178,11 @@ public class BeelineBuilder {
      * ServiceName is the name of the service or application that is creating events.
      * <p>
      * Default: {@code unknown_service:java}
-     * 
+     *
      * @param serviceName to set.
      */
     public BeelineBuilder serviceName(final String serviceName) {
-        this.serviceName = serviceName.trim();
+        this.serviceName = serviceName;
         return this;
     }
 

--- a/beeline-core/src/test/java/io/honeycomb/beeline/builder/BeelineBuilderTest.java
+++ b/beeline-core/src/test/java/io/honeycomb/beeline/builder/BeelineBuilderTest.java
@@ -300,21 +300,49 @@ public class BeelineBuilderTest {
     }
 
     @Test
-    public void writeKeyDatasetAndServiceNameAreTrimmedOfWhiteSpace() {
+    public void writeKeyAndDatasetAreTrimmedOfWhiteSpace() {
         final Beeline beeline = builder
             .writeKey(" " + classicWriteKey + " ")
             .dataSet(" my-dataset ")
             .serviceName(" my-service ")
             .build();
 
-        assertThat(beeline.getServiceName()).isEqualTo("my-service");
+        assertThat(beeline.getServiceName()).isEqualTo(" my-service ");
         verify(mockBuilder, times(1)).writeKey(classicWriteKey);
         verify(mockBuilder, times(1)).dataSet("my-dataset");
         completeNegativeVerification();
     }
 
     @Test
-    public void emptyServiceNameGetsDefaultServiceName() {
+    public void whitespaceServiceNameIsNotTrimmedOfWhitespace() {
+        final Beeline beeline = builder
+            .writeKey(classicWriteKey)
+            .dataSet("my-dataset")
+            .serviceName(" my-service ")
+            .build();
+
+        assertThat(beeline.getServiceName()).isEqualTo(" my-service ");
+        verify(mockBuilder, times(1)).writeKey(classicWriteKey);
+        verify(mockBuilder, times(1)).dataSet("my-dataset");
+        completeNegativeVerification();
+    }
+
+    @Test
+    public void whitespaceServiceNameIsTrimmedForDataset() {
+        final Beeline beeline = builder
+            .writeKey(nonClassicWriteKey)
+            .dataSet("my-dataset")
+            .serviceName(" my-service ")
+            .build();
+
+        assertThat(beeline.getServiceName()).isEqualTo(" my-service ");
+        verify(mockBuilder, times(1)).writeKey(nonClassicWriteKey);
+        verify(mockBuilder, times(1)).dataSet("my-service");
+        completeNegativeVerification();
+    }
+
+    @Test
+    public void emptyServiceNameGetsDefaultServiceNameClassic() {
         final Beeline beeline = builder
             .writeKey(classicWriteKey)
             .serviceName("")
@@ -323,6 +351,32 @@ public class BeelineBuilderTest {
         assertThat(beeline.getServiceName()).startsWith(Beeline.resolveServiceName(""));
         verify(mockBuilder, times(1)).writeKey(classicWriteKey);
         verify(mockBuilder, times(1)).dataSet("beeline-java");
+        completeNegativeVerification();
+    }
+
+    @Test
+    public void emptyServiceNameGetsDefaultServiceNameNonClassic() {
+        final Beeline beeline = builder
+            .writeKey(nonClassicWriteKey)
+            .serviceName("")
+            .build();
+
+        assertThat(beeline.getServiceName()).startsWith(Beeline.resolveServiceName("unknown_service"));
+        verify(mockBuilder, times(1)).writeKey(nonClassicWriteKey);
+        verify(mockBuilder, times(1)).dataSet("unknown_service");
+        completeNegativeVerification();
+    }
+
+    @Test
+    public void whitespaceOnlyServiceNameGetsDefaultDatasetNonClassic() {
+        final Beeline beeline = builder
+            .writeKey(nonClassicWriteKey)
+            .serviceName("  ")
+            .build();
+
+        assertThat(beeline.getServiceName()).startsWith(Beeline.resolveServiceName("  "));
+        verify(mockBuilder, times(1)).writeKey(nonClassicWriteKey);
+        verify(mockBuilder, times(1)).dataSet("unknown_service");
         completeNegativeVerification();
     }
 


### PR DESCRIPTION
<!--
Thank you for contributing to the project! 💜
Please make sure to:
- Chat with us first if this is a big change
  - Open a new issue (or comment on an existing one)
  - We want to make sure you don't spend time implementing something we might have to say No to
- Add unit tests
- Mention any relevant issues in the PR description (e.g. "Fixes #123")

Please see our [OSS process document](https://github.com/honeycombio/home/blob/main/honeycomb-oss-lifecycle-and-practices.md#) to get an idea of how we operate.
-->

## Which problem is this PR solving?

- Previous prep for E&S trimmed service name, but we don't want to mutate service name - we should only trim for the purposes of setting the dataset, and otherwise leave service name as-is.

## Short description of the changes

- don't trim service name
- trim dataset derived from service name, set to unknown_service as needed
- warn on diff if space is in service name that doesn't translate into the dataset
- update tests to confirm non-trimming of service name, and proper setting of default dataset

