### PR TITLE
fix circular dependency for spring boot 2.6.x

### DIFF
--- a/CONTRIBUTORS
+++ b/CONTRIBUTORS
@@ -3,4 +3,5 @@ honeycombio/beeline-java contributors:
 Christian Jank
 Thomas O'Hagan
 Peter Royal
+Giorgi Modebadze
 [Andy Coates](https://github.com/big-andy-coates)

--- a/beeline-spring-boot-starter/src/main/java/io/honeycomb/beeline/spring/autoconfig/BeelineAutoconfig.java
+++ b/beeline-spring-boot-starter/src/main/java/io/honeycomb/beeline/spring/autoconfig/BeelineAutoconfig.java
@@ -1,55 +1,27 @@
 package io.honeycomb.beeline.spring.autoconfig;
 
-import io.honeycomb.beeline.spring.beans.*;
-import io.honeycomb.beeline.spring.beans.aspects.SpanAspect;
-import io.honeycomb.beeline.tracing.Beeline;
-import io.honeycomb.beeline.tracing.Span;
-import io.honeycomb.beeline.tracing.SpanBuilderFactory;
-import io.honeycomb.beeline.tracing.SpanPostProcessor;
-import io.honeycomb.beeline.tracing.Tracer;
+import io.honeycomb.beeline.spring.beans.BeelineHandlerInterceptor;
 import io.honeycomb.beeline.tracing.Tracing;
-import io.honeycomb.beeline.tracing.propagation.HttpHeaderPropagationCodecFactory;
-import io.honeycomb.beeline.tracing.propagation.PropagationCodec;
-import io.honeycomb.beeline.tracing.sampling.Sampling;
-import io.honeycomb.beeline.tracing.sampling.TraceSampler;
-import io.honeycomb.libhoney.EventPostProcessor;
-import io.honeycomb.libhoney.HoneyClient;
 import io.honeycomb.libhoney.LibHoney;
-import io.honeycomb.libhoney.ResponseObserver;
-import io.honeycomb.libhoney.TransportOptions;
-import io.honeycomb.libhoney.builders.HoneyClientBuilder;
-import io.honeycomb.libhoney.transport.Transport;
-import io.honeycomb.libhoney.transport.impl.BatchingHttpTransport;
+import java.util.List;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnClass;
-import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingBean;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnWebApplication;
 import org.springframework.boot.context.properties.EnableConfigurationProperties;
-import org.springframework.boot.web.client.RestTemplateCustomizer;
-import org.springframework.boot.web.servlet.FilterRegistrationBean;
-import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
-import org.springframework.context.annotation.Lazy;
+import org.springframework.context.annotation.Import;
 import org.springframework.web.servlet.config.annotation.InterceptorRegistration;
 import org.springframework.web.servlet.config.annotation.InterceptorRegistry;
 import org.springframework.web.servlet.config.annotation.WebMvcConfigurer;
-
-import javax.servlet.DispatcherType;
-
-import java.net.URI;
-import java.net.URISyntaxException;
-import java.util.List;
-import java.util.Map;
-import java.util.Optional;
 
 @Configuration
 @ConditionalOnClass({LibHoney.class, Tracing.class})
 @EnableConfigurationProperties(BeelineProperties.class)
 @ConditionalOnWebApplication(type = ConditionalOnWebApplication.Type.SERVLET)
 @ConditionalOnProperty(name = "honeycomb.beeline.enabled", matchIfMissing = true)
+@Import(BeelineConfig.class)
 public class BeelineAutoconfig implements WebMvcConfigurer {
-    private static final String BEELINE_USER_AGENT_PREFIX = "beeline/";
 
     @SuppressWarnings("SpringJavaAutowiredFieldsWarningInspection")
     @Autowired
@@ -69,190 +41,5 @@ public class BeelineAutoconfig implements WebMvcConfigurer {
         if (!excludePaths.isEmpty()) {
             interceptorRegistration.excludePathPatterns(excludePaths);
         }
-    }
-
-    @Bean
-    @ConditionalOnMissingBean
-    public Beeline defaultBeeline(final Tracer tracer, final SpanBuilderFactory factory) {
-        return Tracing.createBeeline(tracer, factory);
-    }
-
-    @Bean
-    @ConditionalOnMissingBean
-    public Tracer defaultBeelineTracer(final SpanBuilderFactory factory) {
-        return Tracing.createTracer(factory);
-    }
-
-    @SuppressWarnings({"OptionalUsedAsFieldOrParameterType", "BoundedWildcard"})
-    @Bean
-    @ConditionalOnMissingBean
-    public HoneyClient defaultBeelineHoneyClient(final BeelineProperties beelineProperties,
-                                                 final BeelineMetaFieldProvider metaFieldProvider,
-                                                 final Transport transport,
-                                                 final Optional<ResponseObserver> maybeObserver,
-                                                 final Optional<EventPostProcessor> maybePostProcessor) {
-        // Spring will handle shutdown of the client, see javadoc of the Bean#destroyMethod annotation parameter
-
-        final HoneyClientBuilder builder = new HoneyClientBuilder()
-            .dataSet(beelineProperties.getDataset())
-            .writeKey(beelineProperties.getWriteKey())
-            .transport(transport);
-
-        // set apiHost if not empty
-        if (beelineProperties.getApiHost() != null) {
-            try {
-                builder.apiHost(beelineProperties.getApiHost());
-            } catch (URISyntaxException e) {
-                // eat error for now
-            }
-        }
-
-        // map static and dynamic fields
-        metaFieldProvider.getStaticFields().forEach((key, value) -> builder.addGlobalField(key, value));
-        metaFieldProvider.getDynamicFields().forEach((key, value) -> builder.addGlobalDynamicFields(key, value));
-
-        // if we have a proxy hostname
-        if (!beelineProperties.getProxyHostname().isEmpty()) {
-            // if either username or password are empty
-            if (beelineProperties.getProxyUsername().isEmpty() || beelineProperties.getProxyPassword().isEmpty()) {
-                // add proxy without username & password
-                builder.addProxy(beelineProperties.getProxyHostname());
-            } else {
-                // add proxy with username & password
-                builder.addProxy(
-                    beelineProperties.getProxyHostname(),
-                    beelineProperties.getProxyUsername(),
-                    beelineProperties.getProxyPassword());
-            }
-        }
-
-        maybePostProcessor.ifPresent(builder::eventPostProcessor);
-
-        // final HoneyClient honeyClient = new HoneyClient(options, transport);
-        final HoneyClient honeyClient = builder.build();
-        maybeObserver.ifPresent(honeyClient::addResponseObserver);
-
-        return honeyClient;
-    }
-
-    @Bean
-    @ConditionalOnProperty(name = "honeycomb.beeline.log-honeycomb-responses", matchIfMissing = true)
-    @ConditionalOnMissingBean
-    public ResponseObserver defaultBeelineResponseObserver() {
-        return new DebugResponseObserver();
-    }
-
-    @Bean(destroyMethod = "") // let HoneyClient perform the close on shutdown
-    @ConditionalOnMissingBean
-    public Transport defaultBeelineTransport() {
-        final String additionalUserAgent = BEELINE_USER_AGENT_PREFIX + BeelineConfigUtils.getBeelineVersion();
-        final TransportOptions transportOptions = LibHoney
-            .transportOptions()
-            .setAdditionalUserAgent(additionalUserAgent)
-            .build();
-        return BatchingHttpTransport.init(transportOptions);
-    }
-
-    @Bean
-    @ConditionalOnMissingBean
-    public SpringServletFilter defaultBeelineFilter(final BeelineProperties beelineProperties,
-                                                    final Beeline beeline) {
-        return new SpringServletFilter(
-            beelineProperties.getServiceName(),
-            beelineProperties.getIncludePathPatterns(),
-            beelineProperties.getExcludePathPatterns(),
-            beeline,
-            HttpHeaderPropagationCodecFactory.create(properties.getPropagators())
-        );
-    }
-
-    @Bean
-    public TraceSampler<String> defaultBeelineGlobalSampler(final BeelineProperties beelineProps) {
-        return Sampling.deterministicSampler(beelineProps.getSampleRate());
-    }
-
-    @SuppressWarnings("BoundedWildcard")
-    @Bean
-    @ConditionalOnMissingBean
-    public SpanBuilderFactory defaultBeelineSpanBuilderFactory(final SpanPostProcessor spanPostProcessor,
-                                                               final TraceSampler<String> globalSampler) {
-        return Tracing.createSpanBuilderFactory(spanPostProcessor, globalSampler);
-    }
-
-    @SuppressWarnings({"BoundedWildcard", "OptionalUsedAsFieldOrParameterType"})
-    @Bean
-    @ConditionalOnMissingBean
-    public SpanPostProcessor defaultBeelineSpanProcessor(final HoneyClient client,
-                                                         final Optional<TraceSampler<Span>> maybeSamplingHook) {
-        final TraceSampler<? super Span> samplingHook = maybeSamplingHook.isPresent() ?
-            maybeSamplingHook.get() :
-            Sampling.alwaysSampler();
-        return Tracing.createSpanProcessor(client, samplingHook);
-    }
-
-    @Bean
-    @ConditionalOnMissingBean
-    public BeelineMetaFieldProvider beelineProps(@Lazy final List<BeelineInstrumentation> instrumentations) {
-        return new BeelineMetaFieldProvider(
-            BeelineConfigUtils.getSpringName(),
-            BeelineConfigUtils.getSpringVersion(),
-            BeelineConfigUtils.getBeelineVersion(),
-            BeelineConfigUtils.tryGetLocalHostname(),
-            instrumentations);
-    }
-
-    @Bean
-    @ConditionalOnMissingBean
-    public BeelineHandlerInterceptor defaultBeelineInterceptor(final Tracer tracer, final SpanBuilderFactory factory) {
-        return new BeelineHandlerInterceptor(tracer, factory);
-    }
-
-    @Bean
-    public FilterRegistrationBean<SpringServletFilter> beelineFilterRegistration(
-        final SpringServletFilter filter,
-        final BeelineProperties properties
-    ) {
-        // SpringServletContainerInitializer
-        final FilterRegistrationBean<SpringServletFilter> registration = new FilterRegistrationBean<>(filter);
-        registration.setDispatcherTypes(
-            DispatcherType.REQUEST,
-            DispatcherType.ASYNC,
-            DispatcherType.ERROR,
-            DispatcherType.FORWARD,
-            DispatcherType.INCLUDE);
-        registration.setOrder(properties.getFilterOrder());
-        return registration;
-    }
-
-    @Bean
-    @ConditionalOnProperty(name = "honeycomb.beeline.rest-template.enabled", matchIfMissing = true)
-    public BeelineRestTemplateInterceptor defaultBeelineRestTemplateInterceptor(final Tracer tracer) {
-        PropagationCodec<Map<String, String>> propagationCodec = HttpHeaderPropagationCodecFactory.create(properties.getPropagators());
-        return new BeelineRestTemplateInterceptor(tracer, propagationCodec);
-    }
-
-    @Bean
-    @ConditionalOnProperty(name = "honeycomb.beeline.rest-template.enabled", matchIfMissing = true)
-    public RestTemplateCustomizer defaultBeelineRestTemplateCustomizer(
-        final BeelineRestTemplateInterceptor interceptor
-    ) {
-        return interceptor.customizer();
-    }
-
-    @Bean
-    public SpanAspect defaultBeelineSpanAspect(final Tracer tracer) {
-        return new SpanAspect(tracer);
-    }
-
-    @Bean
-    @ConditionalOnProperty(name = "honeycomb.beeline.jdbc.enabled", havingValue = "true", matchIfMissing = true)
-    public BeelineQueryListenerForJDBC beelineQueryListenerForJDBC(Beeline beeline){
-        return new BeelineQueryListenerForJDBC(beeline);
-    }
-
-    @Bean
-    @ConditionalOnProperty(name = "honeycomb.beeline.jdbc.enabled", havingValue = "true", matchIfMissing = true)
-    public DataSourceProxyBeanPostProcessor proxyBeanPostProcessor(BeelineQueryListenerForJDBC listener){
-        return new DataSourceProxyBeanPostProcessor(listener);
     }
 }

--- a/beeline-spring-boot-starter/src/main/java/io/honeycomb/beeline/spring/autoconfig/BeelineConfig.java
+++ b/beeline-spring-boot-starter/src/main/java/io/honeycomb/beeline/spring/autoconfig/BeelineConfig.java
@@ -42,6 +42,7 @@ import org.springframework.context.annotation.Lazy;
 public class BeelineConfig {
     private static final String BEELINE_USER_AGENT_PREFIX = "beeline/";
 
+    @SuppressWarnings("SpringJavaAutowiredMembersInspection")
     @Autowired
     private BeelineProperties properties;
 
@@ -82,8 +83,8 @@ public class BeelineConfig {
         }
 
         // map static and dynamic fields
-        metaFieldProvider.getStaticFields().forEach((key, value) -> builder.addGlobalField(key, value));
-        metaFieldProvider.getDynamicFields().forEach((key, value) -> builder.addGlobalDynamicFields(key, value));
+        metaFieldProvider.getStaticFields().forEach(builder::addGlobalField);
+        metaFieldProvider.getDynamicFields().forEach(builder::addGlobalDynamicFields);
 
         // if we have a proxy hostname
         if (!beelineProperties.getProxyHostname().isEmpty()) {

--- a/beeline-spring-boot-starter/src/main/java/io/honeycomb/beeline/spring/autoconfig/BeelineConfig.java
+++ b/beeline-spring-boot-starter/src/main/java/io/honeycomb/beeline/spring/autoconfig/BeelineConfig.java
@@ -1,0 +1,232 @@
+package io.honeycomb.beeline.spring.autoconfig;
+
+import io.honeycomb.beeline.spring.beans.BeelineHandlerInterceptor;
+import io.honeycomb.beeline.spring.beans.BeelineInstrumentation;
+import io.honeycomb.beeline.spring.beans.BeelineQueryListenerForJDBC;
+import io.honeycomb.beeline.spring.beans.BeelineRestTemplateInterceptor;
+import io.honeycomb.beeline.spring.beans.DataSourceProxyBeanPostProcessor;
+import io.honeycomb.beeline.spring.beans.DebugResponseObserver;
+import io.honeycomb.beeline.spring.beans.SpringServletFilter;
+import io.honeycomb.beeline.spring.beans.aspects.SpanAspect;
+import io.honeycomb.beeline.tracing.Beeline;
+import io.honeycomb.beeline.tracing.Span;
+import io.honeycomb.beeline.tracing.SpanBuilderFactory;
+import io.honeycomb.beeline.tracing.SpanPostProcessor;
+import io.honeycomb.beeline.tracing.Tracer;
+import io.honeycomb.beeline.tracing.Tracing;
+import io.honeycomb.beeline.tracing.propagation.HttpHeaderPropagationCodecFactory;
+import io.honeycomb.beeline.tracing.propagation.PropagationCodec;
+import io.honeycomb.beeline.tracing.sampling.Sampling;
+import io.honeycomb.beeline.tracing.sampling.TraceSampler;
+import io.honeycomb.libhoney.EventPostProcessor;
+import io.honeycomb.libhoney.HoneyClient;
+import io.honeycomb.libhoney.LibHoney;
+import io.honeycomb.libhoney.ResponseObserver;
+import io.honeycomb.libhoney.TransportOptions;
+import io.honeycomb.libhoney.builders.HoneyClientBuilder;
+import io.honeycomb.libhoney.transport.Transport;
+import io.honeycomb.libhoney.transport.impl.BatchingHttpTransport;
+import java.net.URISyntaxException;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import javax.servlet.DispatcherType;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingBean;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
+import org.springframework.boot.web.client.RestTemplateCustomizer;
+import org.springframework.boot.web.servlet.FilterRegistrationBean;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Lazy;
+
+public class BeelineConfig {
+    private static final String BEELINE_USER_AGENT_PREFIX = "beeline/";
+
+    @Autowired
+    private BeelineProperties properties;
+
+    @Bean
+    @ConditionalOnMissingBean
+    public Beeline defaultBeeline(final Tracer tracer, final SpanBuilderFactory factory) {
+        return Tracing.createBeeline(tracer, factory);
+    }
+
+    @Bean
+    @ConditionalOnMissingBean
+    public Tracer defaultBeelineTracer(final SpanBuilderFactory factory) {
+        return Tracing.createTracer(factory);
+    }
+
+    @SuppressWarnings({"OptionalUsedAsFieldOrParameterType", "BoundedWildcard"})
+    @Bean
+    @ConditionalOnMissingBean
+    public HoneyClient defaultBeelineHoneyClient(final BeelineProperties beelineProperties,
+                                                 final BeelineMetaFieldProvider metaFieldProvider,
+                                                 final Transport transport,
+                                                 final Optional<ResponseObserver> maybeObserver,
+                                                 final Optional<EventPostProcessor> maybePostProcessor) {
+        // Spring will handle shutdown of the client, see javadoc of the Bean#destroyMethod annotation parameter
+
+        final HoneyClientBuilder builder = new HoneyClientBuilder()
+            .dataSet(beelineProperties.getDataset())
+            .writeKey(beelineProperties.getWriteKey())
+            .transport(transport);
+
+        // set apiHost if not empty
+        if (beelineProperties.getApiHost() != null) {
+            try {
+                builder.apiHost(beelineProperties.getApiHost());
+            } catch (URISyntaxException e) {
+                // eat error for now
+            }
+        }
+
+        // map static and dynamic fields
+        metaFieldProvider.getStaticFields().forEach((key, value) -> builder.addGlobalField(key, value));
+        metaFieldProvider.getDynamicFields().forEach((key, value) -> builder.addGlobalDynamicFields(key, value));
+
+        // if we have a proxy hostname
+        if (!beelineProperties.getProxyHostname().isEmpty()) {
+            // if either username or password are empty
+            if (beelineProperties.getProxyUsername().isEmpty() || beelineProperties.getProxyPassword().isEmpty()) {
+                // add proxy without username & password
+                builder.addProxy(beelineProperties.getProxyHostname());
+            } else {
+                // add proxy with username & password
+                builder.addProxy(
+                    beelineProperties.getProxyHostname(),
+                    beelineProperties.getProxyUsername(),
+                    beelineProperties.getProxyPassword());
+            }
+        }
+
+        maybePostProcessor.ifPresent(builder::eventPostProcessor);
+
+        // final HoneyClient honeyClient = new HoneyClient(options, transport);
+        final HoneyClient honeyClient = builder.build();
+        maybeObserver.ifPresent(honeyClient::addResponseObserver);
+
+        return honeyClient;
+    }
+
+    @Bean
+    @ConditionalOnProperty(name = "honeycomb.beeline.log-honeycomb-responses", matchIfMissing = true)
+    @ConditionalOnMissingBean
+    public ResponseObserver defaultBeelineResponseObserver() {
+        return new DebugResponseObserver();
+    }
+
+    @Bean(destroyMethod = "") // let HoneyClient perform the close on shutdown
+    @ConditionalOnMissingBean
+    public Transport defaultBeelineTransport() {
+        final String additionalUserAgent = BEELINE_USER_AGENT_PREFIX + BeelineConfigUtils.getBeelineVersion();
+        final TransportOptions transportOptions = LibHoney
+            .transportOptions()
+            .setAdditionalUserAgent(additionalUserAgent)
+            .build();
+        return BatchingHttpTransport.init(transportOptions);
+    }
+
+    @Bean
+    @ConditionalOnMissingBean
+    public SpringServletFilter defaultBeelineFilter(final BeelineProperties beelineProperties,
+                                                    final Beeline beeline) {
+        return new SpringServletFilter(
+            beelineProperties.getServiceName(),
+            beelineProperties.getIncludePathPatterns(),
+            beelineProperties.getExcludePathPatterns(),
+            beeline,
+            HttpHeaderPropagationCodecFactory.create(properties.getPropagators())
+        );
+    }
+
+    @Bean
+    public TraceSampler<String> defaultBeelineGlobalSampler(final BeelineProperties beelineProps) {
+        return Sampling.deterministicSampler(beelineProps.getSampleRate());
+    }
+
+    @SuppressWarnings("BoundedWildcard")
+    @Bean
+    @ConditionalOnMissingBean
+    public SpanBuilderFactory defaultBeelineSpanBuilderFactory(final SpanPostProcessor spanPostProcessor,
+                                                               final TraceSampler<String> globalSampler) {
+        return Tracing.createSpanBuilderFactory(spanPostProcessor, globalSampler);
+    }
+
+    @SuppressWarnings({"BoundedWildcard", "OptionalUsedAsFieldOrParameterType"})
+    @Bean
+    @ConditionalOnMissingBean
+    public SpanPostProcessor defaultBeelineSpanProcessor(final HoneyClient client,
+                                                         final Optional<TraceSampler<Span>> maybeSamplingHook) {
+        final TraceSampler<? super Span> samplingHook = maybeSamplingHook.isPresent() ?
+            maybeSamplingHook.get() :
+            Sampling.alwaysSampler();
+        return Tracing.createSpanProcessor(client, samplingHook);
+    }
+
+    @Bean
+    @ConditionalOnMissingBean
+    public BeelineMetaFieldProvider beelineProps(@Lazy final List<BeelineInstrumentation> instrumentations) {
+        return new BeelineMetaFieldProvider(
+            BeelineConfigUtils.getSpringName(),
+            BeelineConfigUtils.getSpringVersion(),
+            BeelineConfigUtils.getBeelineVersion(),
+            BeelineConfigUtils.tryGetLocalHostname(),
+            instrumentations);
+    }
+
+    @Bean
+    @ConditionalOnMissingBean
+    public BeelineHandlerInterceptor defaultBeelineInterceptor(final Tracer tracer, final SpanBuilderFactory factory) {
+        return new BeelineHandlerInterceptor(tracer, factory);
+    }
+
+    @Bean
+    public FilterRegistrationBean<SpringServletFilter> beelineFilterRegistration(
+        final SpringServletFilter filter,
+        final BeelineProperties properties
+    ) {
+        // SpringServletContainerInitializer
+        final FilterRegistrationBean<SpringServletFilter> registration = new FilterRegistrationBean<>(filter);
+        registration.setDispatcherTypes(
+            DispatcherType.REQUEST,
+            DispatcherType.ASYNC,
+            DispatcherType.ERROR,
+            DispatcherType.FORWARD,
+            DispatcherType.INCLUDE);
+        registration.setOrder(properties.getFilterOrder());
+        return registration;
+    }
+
+    @Bean
+    @ConditionalOnProperty(name = "honeycomb.beeline.rest-template.enabled", matchIfMissing = true)
+    public BeelineRestTemplateInterceptor defaultBeelineRestTemplateInterceptor(final Tracer tracer) {
+        PropagationCodec<Map<String, String>> propagationCodec = HttpHeaderPropagationCodecFactory.create(properties.getPropagators());
+        return new BeelineRestTemplateInterceptor(tracer, propagationCodec);
+    }
+
+    @Bean
+    @ConditionalOnProperty(name = "honeycomb.beeline.rest-template.enabled", matchIfMissing = true)
+    public RestTemplateCustomizer defaultBeelineRestTemplateCustomizer(
+        final BeelineRestTemplateInterceptor interceptor
+    ) {
+        return interceptor.customizer();
+    }
+
+    @Bean
+    public SpanAspect defaultBeelineSpanAspect(final Tracer tracer) {
+        return new SpanAspect(tracer);
+    }
+
+    @Bean
+    @ConditionalOnProperty(name = "honeycomb.beeline.jdbc.enabled", havingValue = "true", matchIfMissing = true)
+    public BeelineQueryListenerForJDBC beelineQueryListenerForJDBC(Beeline beeline){
+        return new BeelineQueryListenerForJDBC(beeline);
+    }
+
+    @Bean
+    @ConditionalOnProperty(name = "honeycomb.beeline.jdbc.enabled", havingValue = "true", matchIfMissing = true)
+    public DataSourceProxyBeanPostProcessor proxyBeanPostProcessor(BeelineQueryListenerForJDBC listener){
+        return new DataSourceProxyBeanPostProcessor(listener);
+    }
+}


### PR DESCRIPTION
<!--
Thank you for contributing to the project! 💜
Please make sure to:
- Chat with us first if this is a big change
  - Open a new issue (or comment on an existing one)
  - We want to make sure you don't spend time implementing something we might have to say No to
- Add unit tests
- Mention any relevant issues in the PR description (e.g. "Fixes #123")

Please see our [OSS process document](https://github.com/honeycombio/home/blob/main/honeycomb-oss-lifecycle-and-practices.md#) to get an idea of how we operate.
-->

## Which problem is this PR solving?

  * Fixes the [Issue #180](https://github.com/honeycombio/beeline-java/issues/180). Application fails to start because of circular dependencies in Spring 2.6.x and above.


## Short description of the changes
Split autoconfiguration and generic bean configuraiton classes. This way `BeelineAutoconfig` can autowire `BeelineHandlerInterceptor` declared in either `BeelineConfig` or somewhere else. Existing tests already cover the change.



