### PR TITLE
prepare 2.0.0 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@
 ### !!! Breaking Changes !!!
 
 The beeline will no longer propagate `dataset` configuration across distributed traces. To ensure distributed traces continue to send data to the appropriate dataset either:
-1. Configure a `dataset` in every instrumented application (e.g. using the `honeycomb.beeline.dataset` property). This is likely already the case for most users.
+1. [Recommended] Configure a `dataset` in every instrumented application (e.g. using the `honeycomb.beeline.dataset` property). Most users configure their applications this way already, so you may not need to do anything.
 2. Alternatively, configure a [custom trace propagation hook](https://docs.honeycomb.io/getting-data-in/beeline/java/#custom-trace-propagation-hook) to inject dataset in the outgoing request header, and a [custom trace parser hook](https://docs.honeycomb.io/getting-data-in/beeline/java/#custom-trace-parser-hook) to extract dataset from the incoming request header.
 
 ### Enhancements

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,28 @@
 # Beeline Changelog
 
+## [2.0.0] - 2022-03-21
+
+### !!! Breaking Changes !!!
+
+The beeline will no longer propagate `dataset` configuration across distributed traces. To ensure distributed traces continue to send data to the appropriate dataset either:
+1. Configure a `dataset` in every instrumented application (e.g. using the `honeycomb.beeline.dataset` property). This is likely already the case for most users.
+2. Alternatively, configure a [custom trace propagation hook](https://docs.honeycomb.io/getting-data-in/beeline/java/#custom-trace-propagation-hook) to inject dataset in the outgoing request header, and a [custom trace parser hook](https://docs.honeycomb.io/getting-data-in/beeline/java/#custom-trace-parser-hook) to extract dataset from the incoming request header.
+
+### Enhancements
+
+- Add support for Environment & Services (#187) | [@MikeGoldsmith](https://github.com/MikeGoldsmith)
+- add service.name field in addition to service_name (#188) | [@JamieDanielson](https://github.com/JamieDanielson)
+- fix: only trim service name for dataset (#189) | [@JamieDanielson](https://github.com/JamieDanielson)
+
+### Maintenance
+
+- Bump maven-jxr-plugin from 2.5 to 3.1.1 (#126) | [dependabot](https://github.com/dependabot)
+- gh: add re-triage workflow (#174) | [@vreynolds](https://github.com/vreynolds)
+- Bump mockito-core from 4.1.0 to 4.2.0 (#177) | [dependabot](https://github.com/dependabot)
+- update releasing.md for current temporary issue (#178) | [@JamieDanielson](https://github.com/JamieDanielson)
+- update maven orb to handle multi-module project (#179) | [@JamieDanielson](https://github.com/JamieDanielson)
+- merge releases-1.x.x into main (#193) | [@vreynolds](https://github.com/vreynolds)
+
 ## [1.7.1] - 2022-03-18
 
 ### Fixed

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -1,6 +1,6 @@
 # Creating a new release
 
-1. Update the `<version>` tag in each pom.xml in the repo. **temp note**: until issue [#173](https://github.com/honeycombio/beeline-java/issues/173) is resolved, ensure the `beelineVersion` is at least one version behind the main project version.
+1. Update the `<version>` tag in each pom.xml in the repo.
 2. Add new release notes to the Changelog.
 3. Open a PR with those changes.
 4. Once the above PR is merged, tag `main` with the new version, e.g. `v0.1.1`. Push the tags. This will kick off a CI workflow, which will publish a draft GitHub release, and publish artifacts to Maven.

--- a/beeline-core/pom.xml
+++ b/beeline-core/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>io.honeycomb.beeline</groupId>
         <artifactId>beeline-parent</artifactId>
-        <version>1.7.1</version>
+        <version>2.0.0</version>
     </parent>
 
     <name>Beeline Java (Core)</name>

--- a/beeline-spring-boot-sleuth-starter/pom.xml
+++ b/beeline-spring-boot-sleuth-starter/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>io.honeycomb.beeline</groupId>
         <artifactId>beeline-parent</artifactId>
-        <version>1.7.1</version>
+        <version>2.0.0</version>
     </parent>
 
     <name>Beeline Java (Spring Boot Sleuth Starter)</name>

--- a/beeline-spring-boot-starter/pom.xml
+++ b/beeline-spring-boot-starter/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>io.honeycomb.beeline</groupId>
         <artifactId>beeline-parent</artifactId>
-        <version>1.7.1</version>
+        <version>2.0.0</version>
     </parent>
 
     <name>Beeline Java (Spring Boot Starter)</name>

--- a/pom.xml
+++ b/pom.xml
@@ -7,7 +7,7 @@
     <name>Beeline Java (Parent)</name>
     <artifactId>beeline-parent</artifactId>
     <groupId>io.honeycomb.beeline</groupId>
-    <version>1.7.1</version>
+    <version>2.0.0</version>
     <packaging>pom</packaging>
 
     <description>Parent POM for the Honeycomb Beeline for Java</description>


### PR DESCRIPTION
<!--
Thank you for contributing to the project! 💜
Please make sure to:
- Chat with us first if this is a big change
  - Open a new issue (or comment on an existing one)
  - We want to make sure you don't spend time implementing something we might have to say No to
- Add unit tests
- Mention any relevant issues in the PR description (e.g. "Fixes #123")

Please see our [OSS process document](https://github.com/honeycombio/home/blob/main/honeycomb-oss-lifecycle-and-practices.md#) to get an idea of how we operate.
-->

## Which problem is this PR solving?

- breaking release because dataset propagation was removed in #187 

## Short description of the changes

- also removing the releasing docs version weirdness since we saw it work when we released 1.7.1

