### PR TITLE
Add meta.span_type to root/subroot spans

### DIFF
--- a/beeline-core/src/main/java/io/honeycomb/beeline/tracing/Beeline.java
+++ b/beeline-core/src/main/java/io/honeycomb/beeline/tracing/Beeline.java
@@ -243,6 +243,7 @@ public class Beeline {
                 .setSpanName(spanName)
                 .setServiceName(serviceName)
                 .setParentContext(parentContext)
+                .setRoot()
                 .build()
         );
     }

--- a/beeline-core/src/main/java/io/honeycomb/beeline/tracing/Span.java
+++ b/beeline-core/src/main/java/io/honeycomb/beeline/tracing/Span.java
@@ -271,7 +271,7 @@ public class Span implements AutoCloseable {
 
     /**
      * Sets whether the span is a root span within the current process. Root spans are created either by starting
-     * a new trace, or when a span is created using a propgated trace context.
+     * a new trace, or when a span is created using a propagated trace context.
      * @return this Span.
      */
     public Span setRoot() {
@@ -280,7 +280,7 @@ public class Span implements AutoCloseable {
     }
 
     /**
-     * @return am boolean to indicate whether this span is a root span or not.
+     * @return a boolean to indicate whether this span is a root span or not.
      */
     public boolean isRoot() {
         return isRoot;

--- a/beeline-core/src/main/java/io/honeycomb/beeline/tracing/Span.java
+++ b/beeline-core/src/main/java/io/honeycomb/beeline/tracing/Span.java
@@ -407,6 +407,7 @@ public class Span implements AutoCloseable {
                ", spanName='" + getSpanName() + '\'' +
                ", serviceName='" + getServiceName() + '\'' +
                ", parentSpanId='" + getParentSpanId() + '\'' +
+               ", isRoot='" + isRoot() + '\'' +
                ", traceId='" + getTraceId() + '\'' +
                ", spanId='" + getSpanId() + '\'' +
                ", traceFields=" + getTraceFields() +

--- a/beeline-core/src/main/java/io/honeycomb/beeline/tracing/Span.java
+++ b/beeline-core/src/main/java/io/honeycomb/beeline/tracing/Span.java
@@ -269,11 +269,19 @@ public class Span implements AutoCloseable {
         return this;
     }
 
+    /**
+     * Sets whether the span is a root span within the current process. Root spans are created either by starting
+     * a new trace, or when a span is created using a propgated trace context.
+     * @return this Span.
+     */
     public Span setRoot() {
         this.isRoot = true;
         return this;
     }
 
+    /**
+     * @return am boolean to indicate whether this span is a root span or not.
+     */
     public boolean isRoot() {
         return isRoot;
     }

--- a/beeline-core/src/main/java/io/honeycomb/beeline/tracing/Span.java
+++ b/beeline-core/src/main/java/io/honeycomb/beeline/tracing/Span.java
@@ -95,6 +95,8 @@ public class Span implements AutoCloseable {
      */
     private boolean closed;
 
+    private boolean isRoot = false;
+
     /**
      * Constructor that initialises the base Span data.
      * It also calls {@link #markStart} immediately, which may be reset by client code by calling it any other point.
@@ -265,6 +267,15 @@ public class Span implements AutoCloseable {
 
         this.durationMs = duration;
         return this;
+    }
+
+    public Span setRoot() {
+        this.isRoot = true;
+        return this;
+    }
+
+    public boolean isRoot() {
+        return isRoot;
     }
 
     public String getParentSpanId() {

--- a/beeline-core/src/main/java/io/honeycomb/beeline/tracing/SpanBuilderFactory.java
+++ b/beeline-core/src/main/java/io/honeycomb/beeline/tracing/SpanBuilderFactory.java
@@ -166,6 +166,7 @@ public class SpanBuilderFactory {
         @SuppressWarnings("InstanceVariableMayNotBeInitialized")
         private String spanId;
         private PropagationContext parentContext = PropagationContext.emptyContext();
+        private boolean isRoot = false;
 
         public SpanBuilder(final SpanPostProcessor processor,
                            final ClockProvider clock,
@@ -210,6 +211,11 @@ public class SpanBuilderFactory {
 
         public SpanBuilder setSpanId(final String spanId) {
             this.spanId = spanId;
+            return this;
+        }
+
+        public SpanBuilder setRoot() {
+            this.isRoot = true;
             return this;
         }
 
@@ -281,6 +287,9 @@ public class SpanBuilderFactory {
                 processor,
                 clock,
                 sampleRate);
+            if (this.isRoot) {
+                span.setRoot();
+            }
             if (timestamp != null) {
                 span.markStart(timestamp, startTime);
             }

--- a/beeline-core/src/test/java/io/honeycomb/beeline/tracing/SpanBuilderFactoryTest.java
+++ b/beeline-core/src/test/java/io/honeycomb/beeline/tracing/SpanBuilderFactoryTest.java
@@ -249,6 +249,26 @@ public class SpanBuilderFactoryTest {
     }
 
     @Test
+    public void GIVEN_aTracerSpan_WHEN_isRootIsFalse_EXPECT_isRootToBeTrue() {
+        final Span testSpan = getTestSpan();
+        final TracerSpan tracerSpan = new TracerSpan(testSpan, mock(Tracer.class));
+
+        final Span childSpan = factory.createBuilderFromParent(tracerSpan).setSpanName("new-span").build();
+
+        assertThat(childSpan.isRoot() == false);
+    }
+
+    @Test
+    public void GIVEN_aTracerSpan_WHEN_isRootIsTrue_EXPECT_isRootToBeTrue() {
+        final Span testSpan = getTestSpan();
+        final TracerSpan tracerSpan = new TracerSpan(testSpan, mock(Tracer.class));
+
+        final Span childSpan = factory.createBuilderFromParent(tracerSpan).setSpanName("new-span").setRoot().build();
+
+        assertThat(childSpan.isRoot() == true);
+    }
+
+    @Test
     public void GIVEN_aTracerSpan_WHEN_creatingACopyFromATracerSpan_EXPECT_attributesToBePresentOnCopyInstance() {
         final Span testSpan = getTestSpan();
         final TracerSpan tracerSpan = new TracerSpan(testSpan, mock(Tracer.class));

--- a/beeline-core/src/test/java/io/honeycomb/beeline/tracing/SpanBuilderFactoryTest.java
+++ b/beeline-core/src/test/java/io/honeycomb/beeline/tracing/SpanBuilderFactoryTest.java
@@ -249,7 +249,7 @@ public class SpanBuilderFactoryTest {
     }
 
     @Test
-    public void GIVEN_aTracerSpan_WHEN_isRootIsFalse_EXPECT_isRootToBeTrue() {
+    public void GIVEN_aTracerSpan_WHEN_isRootIsFalse_EXPECT_isRootToBeFalse() {
         final Span testSpan = getTestSpan();
         final TracerSpan tracerSpan = new TracerSpan(testSpan, mock(Tracer.class));
 


### PR DESCRIPTION
<!--
Thank you for contributing to the project! 💜
Please make sure to:
- Chat with us first if this is a big change
  - Open a new issue (or comment on an existing one)
  - We want to make sure you don't spend time implementing something we might have to say No to
- Add unit tests
- Mention any relevant issues in the PR description (e.g. "Fixes #123")

Please see our [OSS process document](https://github.com/honeycombio/home/blob/main/honeycomb-oss-lifecycle-and-practices.md#) to get an idea of how we operate.
-->

## Which problem is this PR solving?
Adds support for recording whether a span is a root or subroot span within the trace. Root means it is the very first span across all services and subroot means it is the first span within a given service.

When starting a new trace manually, via instrumentation or via propagation, `StartTrace` is used so this will ensure that meta.span_type is correctly set.

- Closes #202

## Short description of the changes
- Adds setRoot and isRoot to Span
- Add setRoot to SpanBuilder
- During SendingSpan.Close, check for isRoot and add `meta.span_type` if set
- Add tests for SendingSpan and SpanBuilder