### PR TITLE
maint: add Java 18 to CI matrix

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -35,7 +35,7 @@ jobs:
   package:
     executor: &default_executor
       name: maven/default
-      tag: "11.0"
+      tag: "17.0"
     steps:
       - checkout
       - with_cache:
@@ -94,6 +94,7 @@ workflows:
                 - "11.0"
                 - "13.0"
                 - "17.0"
+                - "18.0"
   build:
     jobs:
       - test:


### PR DESCRIPTION
update default version to 17

<!--
Thank you for contributing to the project! 💜
Please make sure to:
- Chat with us first if this is a big change
  - Open a new issue (or comment on an existing one)
  - We want to make sure you don't spend time implementing something we might have to say No to
- Add unit tests
- Mention any relevant issues in the PR description (e.g. "Fixes #123")

Please see our [OSS process document](https://github.com/honeycombio/home/blob/main/honeycomb-oss-lifecycle-and-practices.md#) to get an idea of how we operate.
-->


## Which problem is this PR solving?

- Java 18 was released in March 😄 

## Short description of the changes

- add to test matrix
- use a more recent version (17) by default
