### PR TITLE
Fix project versions and use latest in Spring Boot / Sleuth packages

### DIFF
--- a/beeline-core/src/test/java/io/honeycomb/beeline/tracing/sampling/DeterministicSamplerTest.java
+++ b/beeline-core/src/test/java/io/honeycomb/beeline/tracing/sampling/DeterministicSamplerTest.java
@@ -36,7 +36,7 @@ public class DeterministicSamplerTest {
     public void testThatVariousSampleRatesAreWithinExpectedBounds() {
         final int[] testSampleRates = {2, 10, 20};
         final int numberOfRequestIDsToTest = 50000;
-        final double acceptableMarginOfError = 0.05;
+        final double acceptableMarginOfError = 0.1;
 
         for (int sampleRate : testSampleRates) {
             sampler = new DeterministicTraceSampler(sampleRate);

--- a/beeline-spring-boot-sleuth-starter/pom.xml
+++ b/beeline-spring-boot-sleuth-starter/pom.xml
@@ -15,10 +15,6 @@
     <packaging>jar</packaging>
     <description>Spring Boot Sleuth Starter module to auto-configure Spring Boot Sleuth to send trace data via Honeycomb Beeline for Java</description>
 
-    <properties>
-        <beelineVersion>1.6.1</beelineVersion>
-    </properties>
-
     <build>
         <plugins>
             <plugin>

--- a/beeline-spring-boot-sleuth-starter/pom.xml
+++ b/beeline-spring-boot-sleuth-starter/pom.xml
@@ -15,6 +15,10 @@
     <packaging>jar</packaging>
     <description>Spring Boot Sleuth Starter module to auto-configure Spring Boot Sleuth to send trace data via Honeycomb Beeline for Java</description>
 
+    <properties>
+        <beelineVersion>1.6.1</beelineVersion>
+    </properties>
+
     <build>
         <plugins>
             <plugin>

--- a/beeline-spring-boot-sleuth-starter/src/test/java/io/honeycomb/beeline/spring/beans/BraveBeelineReporterTest.java
+++ b/beeline-spring-boot-sleuth-starter/src/test/java/io/honeycomb/beeline/spring/beans/BraveBeelineReporterTest.java
@@ -58,7 +58,7 @@ public class BraveBeelineReporterTest {
         when(properties.getServiceName()).thenReturn("BraveBeelineReporterTest");
         when(mockTransport.submit(any())).thenReturn(true);
         final BeelineBuilder beelineBuilder = new BeelineBuilder();
-        beeline = spy(beelineBuilder.transport(mockTransport).writeKey("testKey").dataSet("testSet").build());
+        beeline = spy(beelineBuilder.transport(mockTransport).writeKey("testKey").dataSet("testSet").serviceName("testServiceName").build());
         reporter = new BraveBeelineReporter(beeline, properties);
         spanBuilder = Span.newBuilder().name("testSpan").traceId("abcdef0123").id(1234L).parentId(5678L).timestamp(SPAN_TIMESTAMP_NANOS);
     }
@@ -71,7 +71,7 @@ public class BraveBeelineReporterTest {
 
         final ResolvedEvent captured = (ResolvedEvent) captor.getValue();
         Assert.assertEquals("testKey", captured.getWriteKey());
-        Assert.assertEquals("unknown_service", captured.getDataset());
+        Assert.assertEquals("testServiceName", captured.getDataset());
 
         final Map<String, Object> fields = captured.getFields();
         Assert.assertEquals("testspan", fields.get(TraceFieldConstants.SPAN_NAME_FIELD)); // note: zipkin span names are automatically lower-cased

--- a/beeline-spring-boot-sleuth-starter/src/test/java/io/honeycomb/beeline/spring/beans/BraveBeelineReporterTest.java
+++ b/beeline-spring-boot-sleuth-starter/src/test/java/io/honeycomb/beeline/spring/beans/BraveBeelineReporterTest.java
@@ -71,7 +71,7 @@ public class BraveBeelineReporterTest {
 
         final ResolvedEvent captured = (ResolvedEvent) captor.getValue();
         Assert.assertEquals("testKey", captured.getWriteKey());
-        Assert.assertEquals("testSet", captured.getDataset());
+        Assert.assertEquals("unknown_service", captured.getDataset());
 
         final Map<String, Object> fields = captured.getFields();
         Assert.assertEquals("testspan", fields.get(TraceFieldConstants.SPAN_NAME_FIELD)); // note: zipkin span names are automatically lower-cased

--- a/beeline-spring-boot-starter/pom.xml
+++ b/beeline-spring-boot-starter/pom.xml
@@ -15,6 +15,10 @@
     <packaging>jar</packaging>
     <description>Spring Boot Starter module to auto-configure Spring Boot with the Honeycomb Beeline for Java</description>
 
+    <properties>
+        <beelineVersion>1.6.1</beelineVersion>
+    </properties>
+
     <build>
         <plugins>
             <plugin>

--- a/beeline-spring-boot-starter/pom.xml
+++ b/beeline-spring-boot-starter/pom.xml
@@ -15,10 +15,6 @@
     <packaging>jar</packaging>
     <description>Spring Boot Starter module to auto-configure Spring Boot with the Honeycomb Beeline for Java</description>
 
-    <properties>
-        <beelineVersion>1.6.1</beelineVersion>
-    </properties>
-
     <build>
         <plugins>
             <plugin>

--- a/beeline-spring-boot-starter/src/test/java/io/honeycomb/beeline/spring/mockmvctests/MockMvcTest.java
+++ b/beeline-spring-boot-starter/src/test/java/io/honeycomb/beeline/spring/mockmvctests/MockMvcTest.java
@@ -550,24 +550,6 @@ public class MockMvcTest {
     }
 
     @Test
-    public void WHEN_makingARequestWithHoneycombHeaderSpecifyingADataset_EXPECT_AllEventsToSendToDataset() throws Exception {
-        final PropagationContext context = new PropagationContext("current-trace-1", "parent-span-1", "myDataset", Collections.singletonMap("trace-field", "abc"));
-        final Map<String, String> headers = Propagation.honeycombHeaderV1().encode(context).get();
-
-        final MockHttpServletRequestBuilder builder = get("/annotation-span")
-            .header("x-application-header", "fish");
-        headers.forEach((k,v) -> builder.header(k, v));
-        mvc.perform(builder);
-
-        final List<ResolvedEvent> eventFields = captureNoOfEvents(2);
-        final ResolvedEvent aopSpan = eventFields.get(0);
-        final ResolvedEvent requestSpan = eventFields.get(1);
-
-        assertThat(aopSpan.getDataset()).isEqualTo("myDataset");
-        assertThat(requestSpan.getDataset()).isEqualTo("myDataset");
-    }
-
-    @Test
     public void WHEN_makingARequestWithHoneycombHeaderNotSpecifyingAnyDataset_EXPECT_AllEventsToSendToConfiguredDataset() throws Exception {
         final PropagationContext context = new PropagationContext("current-trace-1", "parent-span-1", null, Collections.singletonMap("trace-field", "abc"));
         final Map<String, String> headers = Propagation.honeycombHeaderV1().encode(context).get();

--- a/examples/pom.xml
+++ b/examples/pom.xml
@@ -37,9 +37,9 @@
       </dependency>
 
       <dependency>
-        <groupId>commons-httpclient</groupId>
-        <artifactId>commons-httpclient</artifactId>
-        <version>3.1</version>
+          <groupId>org.apache.httpcomponents.client5</groupId>
+          <artifactId>httpclient5</artifactId>
+          <version>5.1.3</version>
       </dependency>
     </dependencies>
 </project>

--- a/examples/pom.xml
+++ b/examples/pom.xml
@@ -27,7 +27,7 @@
       <dependency>
         <groupId>io.honeycomb.libhoney</groupId>
         <artifactId>libhoney-java</artifactId>
-        <version>1.5.0</version>
+        <version>${libhoneyVersion}</version>
       </dependency>
 
       <dependency>

--- a/examples/pom.xml
+++ b/examples/pom.xml
@@ -21,7 +21,7 @@
         <dependency>
             <groupId>io.honeycomb.beeline</groupId>
             <artifactId>beeline-core</artifactId>
-            <version>2.1.0</version>
+            <version>${beelineVersion}</version>
         </dependency>
 
       <dependency>

--- a/examples/pom.xml
+++ b/examples/pom.xml
@@ -18,11 +18,11 @@
     </properties>
 
     <dependencies>
-        <dependency>
-            <groupId>io.honeycomb.beeline</groupId>
-            <artifactId>beeline-core</artifactId>
-            <version>${beelineVersion}</version>
-        </dependency>
+      <dependency>
+          <groupId>io.honeycomb.beeline</groupId>
+          <artifactId>beeline-core</artifactId>
+          <version>${beelineVersion}</version>
+      </dependency>
 
       <dependency>
         <groupId>io.honeycomb.libhoney</groupId>

--- a/examples/pom.xml
+++ b/examples/pom.xml
@@ -37,9 +37,9 @@
       </dependency>
 
       <dependency>
-          <groupId>org.apache.httpcomponents.client5</groupId>
-          <artifactId>httpclient5</artifactId>
-          <version>5.1.3</version>
+        <groupId>org.apache.httpcomponents.client5</groupId>
+        <artifactId>httpclient5</artifactId>
+        <version>5.1.3</version>
       </dependency>
     </dependencies>
 </project>

--- a/examples/pom.xml
+++ b/examples/pom.xml
@@ -25,12 +25,6 @@
       </dependency>
 
       <dependency>
-        <groupId>io.honeycomb.libhoney</groupId>
-        <artifactId>libhoney-java</artifactId>
-        <version>${libhoneyVersion}</version>
-      </dependency>
-
-      <dependency>
         <groupId>org.apache.httpcomponents</groupId>
         <artifactId>httpclient</artifactId>
         <version>4.5.13</version>

--- a/examples/pom.xml
+++ b/examples/pom.xml
@@ -19,9 +19,9 @@
 
     <dependencies>
       <dependency>
-          <groupId>io.honeycomb.beeline</groupId>
-          <artifactId>beeline-core</artifactId>
-          <version>${beelineVersion}</version>
+        <groupId>io.honeycomb.beeline</groupId>
+        <artifactId>beeline-core</artifactId>
+        <version>${beelineVersion}</version>
       </dependency>
 
       <dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -66,6 +66,7 @@
 
     <properties>
          <!-- Build properties -->
+        <beelineVersion>${project.version}</beelineVersion>
         <dependency.locations.enabled>false</dependency.locations.enabled>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>

--- a/pom.xml
+++ b/pom.xml
@@ -65,7 +65,8 @@
     </developers>
 
     <properties>
-         <!-- Build properties -->
+        <!-- Build properties -->
+        <beelineVersion>${project.version}</beelineVersion>
         <dependency.locations.enabled>false</dependency.locations.enabled>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>

--- a/pom.xml
+++ b/pom.xml
@@ -66,7 +66,6 @@
 
     <properties>
          <!-- Build properties -->
-        <beelineVersion>${project.version}</beelineVersion>
         <dependency.locations.enabled>false</dependency.locations.enabled>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>


### PR DESCRIPTION
<!--
Thank you for contributing to the project! 💜
Please make sure to:
- Chat with us first if this is a big change
  - Open a new issue (or comment on an existing one)
  - We want to make sure you don't spend time implementing something we might have to say No to
- Add unit tests
- Mention any relevant issues in the PR description (e.g. "Fixes #123")

Please see our [OSS process document](https://github.com/honeycombio/home/blob/main/honeycomb-oss-lifecycle-and-practices.md#) to get an idea of how we operate.
-->

## Which problem is this PR solving?
Both the Spring Boot and Sleuth packages need to reference the beeline-core package. These are set as hardcoded values so do not automatically get updated.

This PR creates a new property in the root POM that uses the current beeline project version and this is then used by those packages to keep them inline.

To support moving to beeline v2+ in the spring boot and sleuth packages, a couple of tweaks were needed to accommodate dataset not being populated as part of context propagation.

Also fixes a bug in the examples POM where it uses a hard coded libhoney version instead of the room POMs libhoneyVersion property.

## Short description of the changes
- Create beelineVersion property in root POM
- Use new property in both spring boot and sleuth packages
- Updated spring boot test that asserted dataset was not propagated and used service name
- Updated spring sleuth test that verified dataset value was ignored in place of service name
- Updates example to use the libhoneyVersion property
- Updates example httpclient to a valid version
- Increase sample rate bounds margin to make the test more stable