### PR TITLE
Fix javadoc warnings

### DIFF
--- a/beeline-core/src/main/java/io/honeycomb/beeline/builder/BeelineBuilder.java
+++ b/beeline-core/src/main/java/io/honeycomb/beeline/builder/BeelineBuilder.java
@@ -319,7 +319,7 @@ public class BeelineBuilder {
      * This configuration differs from {@link io.honeycomb.libhoney.TransportOptions.Builder#getMaxConnections()} in that a batch request may be pending
      * completion, but it may be still be waiting for an HTTP connection. This is the case in the default
      * {@link HoneycombBatchConsumer} where the
-     * {@link org.apache.http.nio.client.HttpAsyncClient} maintains an internal unbounded pending queue for
+     * {@link io.honeycomb.libhoney.shaded.org.apache.http.nio.client.HttpAsyncClient} maintains an internal unbounded pending queue for
      * requests that are waiting for a connection. This configuration effectively puts a bound on the total
      * number of batch requests being serviced by the HTTP client, regardless of whether they have
      * a connection or not.
@@ -341,7 +341,7 @@ public class BeelineBuilder {
      * Default: 200
      *
      * @param maxConnections maximum number of connections.
-     * @see org.apache.http.impl.nio.client.HttpAsyncClientBuilder#setMaxConnTotal(int)
+     * @see io.honeycomb.libhoney.shaded.org.apache.http.impl.nio.client.HttpAsyncClientBuilder#setMaxConnTotal(int)
      */
     public BeelineBuilder maxConnections(final int maxConnections) {
         clientBuilder.maxConnections(maxConnections);
@@ -356,7 +356,7 @@ public class BeelineBuilder {
      * Default: 100
      *
      * @param maxConnectionsPerApiHost pool size for per hostname
-     * @see org.apache.http.impl.nio.client.HttpAsyncClientBuilder#setMaxConnPerRoute(int)
+     * @see io.honeycomb.libhoney.shaded.org.apache.http.impl.nio.client.HttpAsyncClientBuilder#setMaxConnPerRoute(int)
      */
     public BeelineBuilder maxConnectionsPerApiHost(final int maxConnectionsPerApiHost) {
         clientBuilder.maxConnectionsPerApiHost(maxConnectionsPerApiHost);
@@ -369,7 +369,7 @@ public class BeelineBuilder {
      * Default: 0
      *
      * @param connectTimeout to set.
-     * @see org.apache.http.client.config.RequestConfig#getConnectTimeout()
+     * @see io.honeycomb.libhoney.shaded.org.apache.http.client.config.RequestConfig#getConnectTimeout()
      */
     public BeelineBuilder connectionTimeout(final int connectTimeout) {
         clientBuilder.connectionTimeout(connectTimeout);
@@ -388,7 +388,7 @@ public class BeelineBuilder {
      * Default: 0
      *
      * @param connectionRequestTimeout to set.
-     * @see org.apache.http.client.config.RequestConfig#getConnectionRequestTimeout()
+     * @see io.honeycomb.libhoney.shaded.org.apache.http.client.config.RequestConfig#getConnectionRequestTimeout()
      */
     public BeelineBuilder connectionRequestTimeout(final int connectionRequestTimeout) {
         clientBuilder.connectionRequestTimeout(connectionRequestTimeout);
@@ -401,7 +401,7 @@ public class BeelineBuilder {
      * Default: 3000
      *
      * @param socketTimeout to set.
-     * @see org.apache.http.client.config.RequestConfig#getSocketTimeout()
+     * @see io.honeycomb.libhoney.shaded.org.apache.http.client.config.RequestConfig#getSocketTimeout()
      */
     public BeelineBuilder socketTimeout(final int socketTimeout) {
         clientBuilder.socketTimeout(socketTimeout);
@@ -414,7 +414,7 @@ public class BeelineBuilder {
      * Default: 8192
      *
      * @param bufferSize to set.
-     * @see org.apache.http.config.ConnectionConfig.Builder#setBufferSize(int)
+     * @see io.honeycomb.libhoney.shaded.org.apache.http.config.ConnectionConfig.Builder#setBufferSize(int)
      */
     public BeelineBuilder bufferSize(final int bufferSize) {
         clientBuilder.bufferSize(bufferSize);
@@ -428,7 +428,7 @@ public class BeelineBuilder {
      *
      * @param ioThreadCount to set, must be between 1 and the system's number of CPU cores.
      * @see <a href="https://hc.apache.org/httpcomponents-core-ga/tutorial/html/nio.html">Apache http client NIO</a>
-     * @see org.apache.http.impl.nio.reactor.IOReactorConfig#getIoThreadCount()
+     * @see io.honeycomb.libhoney.shaded.org.apache.http.impl.nio.reactor.IOReactorConfig#getIoThreadCount()
      */
     public BeelineBuilder ioThreadCount(final int ioThreadCount) {
         clientBuilder.ioThreadCount(ioThreadCount);

--- a/beeline-core/src/main/java/io/honeycomb/beeline/tracing/ids/W3CTraceIdProvider.java
+++ b/beeline-core/src/main/java/io/honeycomb/beeline/tracing/ids/W3CTraceIdProvider.java
@@ -62,7 +62,7 @@ public class W3CTraceIdProvider implements TraceIdProvider {
     /**
      * Validates the provided traceId.
      * Intended for internal use only.
-     * @param traceId
+     * @param traceId the trace ID to validate.
      * @throws IllegalArgumentException
      *         If the traceId is not valid.
      */
@@ -74,7 +74,7 @@ public class W3CTraceIdProvider implements TraceIdProvider {
 
     /**
      * Validates the provided traceId.
-     * @param spanId
+     * @param traceId the trace ID to validate.
      * @return boolean whether the traceId is valid or not.
      */
     public static Boolean isValidTraceId(String traceId) {
@@ -87,7 +87,7 @@ public class W3CTraceIdProvider implements TraceIdProvider {
     /**
      * Validates the provided spanId.
      * Intended for internal use only.
-     * @param traceId
+     * @param spanId the span ID to validate.
      * @throws IllegalArgumentException
      *         If the spanId is not valid.
      */
@@ -99,7 +99,7 @@ public class W3CTraceIdProvider implements TraceIdProvider {
 
     /**
      * Validates the provided spanId.
-     * @param spanId
+     * @param spanId the span ID to validate.
      * @return boolean whether the spanId is valid or not.
      */
     public static Boolean isValidSpanId(String spanId) {

--- a/beeline-core/src/main/java/io/honeycomb/beeline/tracing/propagation/AWSPropagationCodec.java
+++ b/beeline-core/src/main/java/io/honeycomb/beeline/tracing/propagation/AWSPropagationCodec.java
@@ -63,7 +63,7 @@ public class AWSPropagationCodec implements PropagationCodec<Map<String, String>
      * will be used.
      * </p>
      *
-     * @param encodedTrace to decode into a {@link PropagationContext}.
+     * @param headers to decode into a {@link PropagationContext}.
      * @return extracted context - "empty" context if encodedTrace value has an invalid format or is null.
      */
     @Override

--- a/beeline-core/src/main/java/io/honeycomb/beeline/tracing/propagation/HttpHeaderPropagationCodecFactory.java
+++ b/beeline-core/src/main/java/io/honeycomb/beeline/tracing/propagation/HttpHeaderPropagationCodecFactory.java
@@ -13,7 +13,7 @@ public class HttpHeaderPropagationCodecFactory {
      * Returns a {@link HttpHeaderPropagationCodecFactory} if no valid codec names
      * are provided.
      * </p>
-     * Returns a {@link CompositeHttpHeaderPropagtor} if more than one valid codec
+     * Returns a {@link CompositeHttpHeaderPropagator} if more than one valid codec
      * is provided.
      *
      * @param propagatorNames the named of the codecs to use

--- a/beeline-core/src/main/java/io/honeycomb/beeline/tracing/propagation/HttpHeaderV1PropagationCodec.java
+++ b/beeline-core/src/main/java/io/honeycomb/beeline/tracing/propagation/HttpHeaderV1PropagationCodec.java
@@ -88,10 +88,10 @@ public class HttpHeaderV1PropagationCodec implements PropagationCodec<Map<String
      * <p>
      * Trace_id and parent_id are required to create a non-empty Propagation context, while dataset and context are
      * treated as optional.
-     * 
+     *
      * NOTE: This codec no longer encodes or decodes dataset from the trace header.
      *
-     * @param encodedTrace to decode into a {@link PropagationContext}.
+     * @param headers to decode into a {@link PropagationContext}.
      * @return extracted context - "empty" context if encodedTrace value has an invalid format or is null.
      */
     @SuppressWarnings({"OverlyComplexMethod", "OverlyLongMethod"})

--- a/beeline-core/src/main/java/io/honeycomb/beeline/tracing/propagation/W3CPropagationCodec.java
+++ b/beeline-core/src/main/java/io/honeycomb/beeline/tracing/propagation/W3CPropagationCodec.java
@@ -70,7 +70,7 @@ public class W3CPropagationCodec implements PropagationCodec<Map<String, String>
      *
      * </p>
      *
-     * @param encodedTrace to decode into a {@link PropagationContext}.
+     * @param headers to decode into a {@link PropagationContext}.
      * @return extracted context - "empty" context if encodedTrace value has an invalid format or is null.
      */
     @Override


### PR DESCRIPTION
<!--
Thank you for contributing to the project! 💜
Please make sure to:
- Chat with us first if this is a big change
  - Open a new issue (or comment on an existing one)
  - We want to make sure you don't spend time implementing something we might have to say No to
- Add unit tests
- Mention any relevant issues in the PR description (e.g. "Fixes #123")

Please see our [OSS process document](https://github.com/honeycombio/home/blob/main/honeycomb-oss-lifecycle-and-practices.md#) to get an idea of how we operate.
-->

## Which problem is this PR solving?
Fixes javadoc warnings for incorrect param name, spelling error or import path.

## Short description of the changes
- Fix javadoc warnings