### PR TITLE
docs: add otel recommendation to readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,6 +3,8 @@
 [![OSS Lifecycle](https://img.shields.io/osslifecycle/honeycombio/beeline-java?color=success)](https://github.com/honeycombio/home/blob/main/honeycomb-oss-lifecycle-and-practices.md)
 [![CircleCI](https://circleci.com/gh/honeycombio/beeline-java.svg?style=shield)](https://circleci.com/gh/honeycombio/beeline-java) [![Beeline Core](https://img.shields.io/maven-central/v/io.honeycomb.beeline/beeline-core.svg)](https://search.maven.org/search?q=a:beeline-core) [![Beeline Spring Boot Starter](https://img.shields.io/maven-central/v/io.honeycomb.beeline/beeline-spring-boot-starter.svg)](https://search.maven.org/search?q=a:beeline-spring-boot-starter)
 
+**Note**: Honeycomb embraces OpenTelemetry as the effective way to instrument applications. For any new observability efforts, we recommend [instrumenting with OpenTelemetry](https://docs.honeycomb.io/getting-data-in/opentelemetry/java-distro/).
+
 This package makes it easy to instrument your Java web application to send useful events to
 [Honeycomb](https://www.honeycomb.io), a service for debugging your software in production.
 


### PR DESCRIPTION
## Which problem is this PR solving?
This addition to the README makes it clear that Honeycomb recommends instrumenting any new observability efforts with OpenTelemetry

## Short description of the changes
- Add paragraph to README recommending OTel
