### PR TITLE
feat: support classic ingest keys

### DIFF
--- a/beeline-core/src/main/java/io/honeycomb/beeline/builder/BeelineBuilder.java
+++ b/beeline-core/src/main/java/io/honeycomb/beeline/builder/BeelineBuilder.java
@@ -25,6 +25,8 @@ import javax.net.ssl.SSLContext;
 import java.net.URI;
 import java.net.URISyntaxException;
 
+import static io.honeycomb.libhoney.Options.isClassic;
+
 public class BeelineBuilder {
     protected HoneyClientBuilder clientBuilder = new HoneyClientBuilder();
     private SpanBuilderFactory defaultFactory = null;
@@ -60,7 +62,7 @@ public class BeelineBuilder {
             clientBuilder.writeKey(writeKey);
         }
 
-        if (ObjectUtils.isNullOrEmpty(writeKey) || isClassic(writeKey)) {
+        if (isClassic(writeKey)) {
             if (ObjectUtils.isNullOrEmpty(dataset)) {
                 System.err.println("empty dataset");
                 clientBuilder.dataSet(defualtDatasetClassic);
@@ -87,10 +89,6 @@ public class BeelineBuilder {
         }
 
         return createBeeline(clientBuilder.build());
-    }
-
-    private Boolean isClassic(String apiKey) {
-        return apiKey.length() == 32;
     }
 
     @SuppressWarnings("unchecked")

--- a/beeline-core/src/test/java/io/honeycomb/beeline/builder/BeelineBuilderTest.java
+++ b/beeline-core/src/test/java/io/honeycomb/beeline/builder/BeelineBuilderTest.java
@@ -31,7 +31,9 @@ import static org.mockito.Mockito.when;
 public class BeelineBuilderTest {
 
     private static final String classicWriteKey = "e38be416d0d68f9ed1e96432ac1a3380";
+    private static final String classicIngestKey = "hcaic_1234567890123456789012345678901234567890123456789012345678";
     private static final String nonClassicWriteKey = "d68f9ed1e96432ac1a3380";
+    private static final String nonClassicIngestKey = "hcxik_01hqk4k20cjeh63wca8vva5stw70nft6m5n8wr8f5mjx3762s8269j50wc";
 
     BeelineBuilder builder;
     HoneyClientBuilder mockBuilder;
@@ -86,6 +88,14 @@ public class BeelineBuilderTest {
     public void writeKey() {
         final Beeline beeline = builder.writeKey(classicWriteKey).build();
         verify(mockBuilder, times(1)).writeKey(classicWriteKey);
+        verify(mockBuilder, times(1)).dataSet("beeline-java");
+        completeNegativeVerification();
+    }
+
+    @Test
+    public void classicIngestKey() {
+        final Beeline beeline = builder.writeKey(classicIngestKey).build();
+        verify(mockBuilder, times(1)).writeKey(classicIngestKey);
         verify(mockBuilder, times(1)).dataSet("beeline-java");
         completeNegativeVerification();
     }
@@ -290,6 +300,16 @@ public class BeelineBuilderTest {
     }
 
     @Test
+    public void classicIngesteKeyGetsDefaultClassicDataset() {
+        final Beeline beeline = builder.writeKey(classicIngestKey).build();
+
+        assertThat(beeline.getServiceName()).isEqualTo(Beeline.resolveServiceName(""));
+        verify(mockBuilder, times(1)).writeKey(classicIngestKey);
+        verify(mockBuilder, times(1)).dataSet("beeline-java");
+        completeNegativeVerification();
+    }
+
+    @Test
     public void modernWriteKeyGetsDefaultNonClassicDataset() {
         final Beeline beeline = builder.writeKey(nonClassicWriteKey).build();
 
@@ -300,7 +320,17 @@ public class BeelineBuilderTest {
     }
 
     @Test
-    public void writeKeyAndDatasetAreTrimmedOfWhiteSpace() {
+    public void ingestKeyGetsDefaultNonClassicDataset() {
+        final Beeline beeline = builder.writeKey(nonClassicIngestKey).build();
+
+        assertThat(beeline.getServiceName()).isEqualTo(Beeline.resolveServiceName(""));
+        verify(mockBuilder, times(1)).writeKey(nonClassicIngestKey);
+        verify(mockBuilder, times(1)).dataSet("unknown_service");
+        completeNegativeVerification();
+    }
+
+    @Test
+    public void writeKeyAndDatasetAreTrimmedOfWhiteSpaceClassic() {
         final Beeline beeline = builder
             .writeKey(" " + classicWriteKey + " ")
             .dataSet(" my-dataset ")
@@ -314,7 +344,21 @@ public class BeelineBuilderTest {
     }
 
     @Test
-    public void whitespaceServiceNameIsNotTrimmedOfWhitespace() {
+    public void writeKeyAndDatasetAreTrimmedOfWhiteSpaceClassicIngestKey() {
+        final Beeline beeline = builder
+            .writeKey(" " + classicIngestKey + " ")
+            .dataSet(" my-dataset ")
+            .serviceName(" my-service ")
+            .build();
+
+        assertThat(beeline.getServiceName()).isEqualTo(" my-service ");
+        verify(mockBuilder, times(1)).writeKey(classicIngestKey);
+        verify(mockBuilder, times(1)).dataSet("my-dataset");
+        completeNegativeVerification();
+    }
+
+    @Test
+    public void whitespaceServiceNameIsNotTrimmedOfWhitespaceClassic() {
         final Beeline beeline = builder
             .writeKey(classicWriteKey)
             .dataSet("my-dataset")
@@ -328,7 +372,21 @@ public class BeelineBuilderTest {
     }
 
     @Test
-    public void whitespaceServiceNameIsTrimmedForDataset() {
+    public void whitespaceServiceNameIsNotTrimmedOfWhitespaceClassicIngestKey() {
+        final Beeline beeline = builder
+            .writeKey(classicIngestKey)
+            .dataSet("my-dataset")
+            .serviceName(" my-service ")
+            .build();
+
+        assertThat(beeline.getServiceName()).isEqualTo(" my-service ");
+        verify(mockBuilder, times(1)).writeKey(classicIngestKey);
+        verify(mockBuilder, times(1)).dataSet("my-dataset");
+        completeNegativeVerification();
+    }
+
+    @Test
+    public void whitespaceServiceNameIsTrimmedForDatasetNonClassic() {
         final Beeline beeline = builder
             .writeKey(nonClassicWriteKey)
             .dataSet("my-dataset")
@@ -337,6 +395,20 @@ public class BeelineBuilderTest {
 
         assertThat(beeline.getServiceName()).isEqualTo(" my-service ");
         verify(mockBuilder, times(1)).writeKey(nonClassicWriteKey);
+        verify(mockBuilder, times(1)).dataSet("my-service");
+        completeNegativeVerification();
+    }
+
+    @Test
+    public void whitespaceServiceNameIsTrimmedForDatasetNonClassicIngestKey() {
+        final Beeline beeline = builder
+            .writeKey(nonClassicIngestKey)
+            .dataSet("my-dataset")
+            .serviceName(" my-service ")
+            .build();
+
+        assertThat(beeline.getServiceName()).isEqualTo(" my-service ");
+        verify(mockBuilder, times(1)).writeKey(nonClassicIngestKey);
         verify(mockBuilder, times(1)).dataSet("my-service");
         completeNegativeVerification();
     }
@@ -355,6 +427,19 @@ public class BeelineBuilderTest {
     }
 
     @Test
+    public void emptyServiceNameGetsDefaultServiceNameClassicIngestKey() {
+        final Beeline beeline = builder
+            .writeKey(classicIngestKey)
+            .serviceName("")
+            .build();
+
+        assertThat(beeline.getServiceName()).startsWith(Beeline.resolveServiceName(""));
+        verify(mockBuilder, times(1)).writeKey(classicIngestKey);
+        verify(mockBuilder, times(1)).dataSet("beeline-java");
+        completeNegativeVerification();
+    }
+
+    @Test
     public void emptyServiceNameGetsDefaultServiceNameNonClassic() {
         final Beeline beeline = builder
             .writeKey(nonClassicWriteKey)
@@ -368,6 +453,19 @@ public class BeelineBuilderTest {
     }
 
     @Test
+    public void emptyServiceNameGetsDefaultServiceNameNonClassicIngestKey() {
+        final Beeline beeline = builder
+            .writeKey(nonClassicIngestKey)
+            .serviceName("")
+            .build();
+
+        assertThat(beeline.getServiceName()).startsWith(Beeline.resolveServiceName("unknown_service"));
+        verify(mockBuilder, times(1)).writeKey(nonClassicIngestKey);
+        verify(mockBuilder, times(1)).dataSet("unknown_service");
+        completeNegativeVerification();
+    }
+
+    @Test
     public void whitespaceOnlyServiceNameGetsDefaultDatasetNonClassic() {
         final Beeline beeline = builder
             .writeKey(nonClassicWriteKey)
@@ -376,6 +474,19 @@ public class BeelineBuilderTest {
 
         assertThat(beeline.getServiceName()).startsWith(Beeline.resolveServiceName("  "));
         verify(mockBuilder, times(1)).writeKey(nonClassicWriteKey);
+        verify(mockBuilder, times(1)).dataSet("unknown_service");
+        completeNegativeVerification();
+    }
+
+    @Test
+    public void whitespaceOnlyServiceNameGetsDefaultDatasetNonClassicIngestKey() {
+        final Beeline beeline = builder
+            .writeKey(nonClassicIngestKey)
+            .serviceName("  ")
+            .build();
+
+        assertThat(beeline.getServiceName()).startsWith(Beeline.resolveServiceName("  "));
+        verify(mockBuilder, times(1)).writeKey(nonClassicIngestKey);
         verify(mockBuilder, times(1)).dataSet("unknown_service");
         completeNegativeVerification();
     }

--- a/pom.xml
+++ b/pom.xml
@@ -73,7 +73,7 @@
         <jdkVersion>1.8</jdkVersion>
 
         <!-- COMPILE dependency versions  -->
-        <libhoneyVersion>1.5.4</libhoneyVersion>
+        <libhoneyVersion>1.6.0</libhoneyVersion>
         <springBootVersion>2.1.1.RELEASE</springBootVersion>
 
         <!-- TEST dependency versions  -->


### PR DESCRIPTION
## Which problem is this PR solving?

We [recently](https://github.com/honeycombio/libhoney-java/releases/tag/v1.6.0) updated libhoney-java to support classic ingest keys. This PR updates the beeline to this version of libhoney-java and swaps isClassic to use the new static method from libhoney.

## Short description of the changes

- bumps libhoney-java version from 1.5.4 to 1.6.0
- removes `BeelineBuilder.isClassic` in favor of `libhoney.Options.isClassic`
- Adds several tests that use classic/non-classic ingest keys to verify it works


