### PR TITLE
fix: set service name in spring boot starter

### DIFF
--- a/beeline-core/src/main/java/io/honeycomb/beeline/builder/BeelineBuilder.java
+++ b/beeline-core/src/main/java/io/honeycomb/beeline/builder/BeelineBuilder.java
@@ -38,7 +38,7 @@ public class BeelineBuilder {
     private String dataset = null;
     private String serviceName = null;
 
-    private static final String defualtDatasetClassic = "beeline-java";
+    private static final String defaultDatasetClassic = "beeline-java";
 
     /**
      * Build new Beeline instance as configured by calling the various builder methods previous to this call.
@@ -65,7 +65,7 @@ public class BeelineBuilder {
         if (isClassic(writeKey)) {
             if (ObjectUtils.isNullOrEmpty(dataset)) {
                 System.err.println("empty dataset");
-                clientBuilder.dataSet(defualtDatasetClassic);
+                clientBuilder.dataSet(defaultDatasetClassic);
             } else {
                 clientBuilder.dataSet(dataset);
             }

--- a/beeline-core/src/main/java/io/honeycomb/beeline/tracing/Beeline.java
+++ b/beeline-core/src/main/java/io/honeycomb/beeline/tracing/Beeline.java
@@ -74,7 +74,7 @@ public class Beeline {
     private final String serviceName;
 
     public static final String defaultServiceName = "unknown_service";
-    public static final String defualtProcessName = "java";
+    public static final String defaultProcessName = "java";
 
     public Beeline(final Tracer tracer, final SpanBuilderFactory factory) {
         this(tracer, factory, null);
@@ -102,9 +102,9 @@ public class Beeline {
                 File f = new File(dir, mainClass);
                 processName = f.getName();
             } catch (RuntimeException e) {
-                throw e;
+                processName = defaultProcessName;
             } catch (Exception e) {
-                processName = defaultServiceName;
+                processName = defaultProcessName;
             }
             return String.join(":", defaultServiceName, processName);
         }

--- a/beeline-spring-boot-starter/src/main/java/io/honeycomb/beeline/spring/autoconfig/BeelineConfig.java
+++ b/beeline-spring-boot-starter/src/main/java/io/honeycomb/beeline/spring/autoconfig/BeelineConfig.java
@@ -48,8 +48,8 @@ public class BeelineConfig {
 
     @Bean
     @ConditionalOnMissingBean
-    public Beeline defaultBeeline(final Tracer tracer, final SpanBuilderFactory factory) {
-        return Tracing.createBeeline(tracer, factory);
+    public Beeline defaultBeeline(final Tracer tracer, final SpanBuilderFactory factory, final BeelineProperties beelineProperties) {
+        return Tracing.createBeeline(tracer, factory, beelineProperties.getServiceName());
     }
 
     @Bean
@@ -69,7 +69,8 @@ public class BeelineConfig {
         // Spring will handle shutdown of the client, see javadoc of the Bean#destroyMethod annotation parameter
 
         final HoneyClientBuilder builder = new HoneyClientBuilder()
-            .dataSet(beelineProperties.getDataset())
+            // TODO: use dataset if classic
+            .dataSet(beelineProperties.getServiceName())
             .writeKey(beelineProperties.getWriteKey())
             .transport(transport);
 

--- a/example-spring/pom.xml
+++ b/example-spring/pom.xml
@@ -1,0 +1,71 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+    <parent>
+          <groupId>io.honeycomb.beeline</groupId>
+          <artifactId>beeline-parent</artifactId>
+          <version>2.2.0</version>
+    </parent>
+
+    <groupId>io.honeycomb.beeline</groupId>
+    <artifactId>example-spring</artifactId>
+    <version>2.2.0</version>
+
+    <properties>
+        <maven.compiler.source>17</maven.compiler.source>
+        <maven.compiler.target>17</maven.compiler.target>
+        <java.version>17</java.version>
+        <spring.boot.version>2.4.3</spring.boot.version>
+    </properties>
+
+    <dependencyManagement>
+        <dependencies>
+            <dependency>
+                <groupId>org.springframework.boot</groupId>
+                <artifactId>spring-boot-dependencies</artifactId>
+                <version>${spring.boot.version}</version>
+                <type>pom</type>
+                <scope>import</scope>
+            </dependency>
+        </dependencies>
+    </dependencyManagement>
+
+	<dependencies>
+        <dependency>
+            <groupId>io.honeycomb.beeline</groupId>
+            <artifactId>beeline-spring-boot-starter</artifactId>
+            <version>${beelineVersion}</version>
+        </dependency>
+
+		<dependency>
+			<groupId>org.springframework.boot</groupId>
+			<artifactId>spring-boot-starter-web</artifactId>
+		</dependency>
+
+		<!-- tag::actuator[] -->
+		<dependency>
+			<groupId>org.springframework.boot</groupId>
+			<artifactId>spring-boot-starter-actuator</artifactId>
+		</dependency>
+		<!-- end::actuator[] -->
+
+		<!-- tag::tests[] -->
+		<dependency>
+			<groupId>org.springframework.boot</groupId>
+			<artifactId>spring-boot-starter-test</artifactId>
+			<scope>test</scope>
+		</dependency>
+		<!-- end::tests[] -->
+	</dependencies>
+
+	<build>
+		<plugins>
+			<plugin>
+				<groupId>org.springframework.boot</groupId>
+				<artifactId>spring-boot-maven-plugin</artifactId>
+			</plugin>
+		</plugins>
+	</build>
+</project>

--- a/example-spring/src/main/java/io/honeycomb/beeline/Application.java
+++ b/example-spring/src/main/java/io/honeycomb/beeline/Application.java
@@ -1,0 +1,13 @@
+package io.honeycomb.beeline;
+
+import org.springframework.boot.SpringApplication;
+import org.springframework.boot.autoconfigure.SpringBootApplication;
+
+@SpringBootApplication
+public class Application {
+    public static void main(String[] args) {
+        SpringApplication.run(Application.class, args);
+        System.out.println("Hello World!");
+    }
+
+}

--- a/example-spring/src/main/java/io/honeycomb/beeline/HelloController.java
+++ b/example-spring/src/main/java/io/honeycomb/beeline/HelloController.java
@@ -1,0 +1,13 @@
+package src.main.java.io.honeycomb.beeline;
+
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+public class HelloController {
+
+  @GetMapping("/")
+  public String index() {
+    return "Greetings from Spring Boot!";
+  }
+}

--- a/pom.xml
+++ b/pom.xml
@@ -30,6 +30,7 @@
         <module>beeline-spring-boot-starter</module>
         <module>beeline-spring-boot-sleuth-starter</module>
         <module>examples</module>
+        <module>example-spring</module>
     </modules>
 
     <scm>


### PR DESCRIPTION
## Which problem is this PR solving?

- When using a non-classic API key... `service.name` is not properly set, resulting in traces ending up in wrong dataset. For example, with `dataset=my-dataset` and `service.name=my-service`, traces should show up in `my-service` dataset.

## Short description of the changes

- set `service.name` in spring boot starter
- use process name instead of service name for default fallback
- don't throw on runtime exception
- add example spring app for manual testing
