### PR TITLE
fix: set service name in spring boot starter

### DIFF
--- a/beeline-core/src/main/java/io/honeycomb/beeline/tracing/Beeline.java
+++ b/beeline-core/src/main/java/io/honeycomb/beeline/tracing/Beeline.java
@@ -102,9 +102,12 @@ public class Beeline {
                 File f = new File(dir, mainClass);
                 processName = f.getName();
             } catch (RuntimeException e) {
-                throw e;
+                // the above code can throw an exception if the location is not found
+                // so catch that exception and fallback to default process name.
+                // Exception (next catch) does not include RuntimeException
+                processName = defaultProcessName;
             } catch (Exception e) {
-                processName = defaultServiceName;
+                processName = defaultProcessName;
             }
             return String.join(":", defaultServiceName, processName);
         }

--- a/beeline-spring-boot-starter/src/main/java/io/honeycomb/beeline/spring/autoconfig/BeelineConfig.java
+++ b/beeline-spring-boot-starter/src/main/java/io/honeycomb/beeline/spring/autoconfig/BeelineConfig.java
@@ -48,8 +48,8 @@ public class BeelineConfig {
 
     @Bean
     @ConditionalOnMissingBean
-    public Beeline defaultBeeline(final Tracer tracer, final SpanBuilderFactory factory) {
-        return Tracing.createBeeline(tracer, factory);
+    public Beeline defaultBeeline(final Tracer tracer, final SpanBuilderFactory factory, final BeelineProperties beelineProperties) {
+        return Tracing.createBeeline(tracer, factory, beelineProperties.getServiceName());
     }
 
     @Bean
@@ -69,7 +69,8 @@ public class BeelineConfig {
         // Spring will handle shutdown of the client, see javadoc of the Bean#destroyMethod annotation parameter
 
         final HoneyClientBuilder builder = new HoneyClientBuilder()
-            .dataSet(beelineProperties.getDataset())
+            // todo use dataset if classic
+            .dataSet(beelineProperties.getServiceName())
             .writeKey(beelineProperties.getWriteKey())
             .transport(transport);
 

--- a/beeline-spring-boot-starter/src/main/java/io/honeycomb/beeline/spring/autoconfig/BeelineConfig.java
+++ b/beeline-spring-boot-starter/src/main/java/io/honeycomb/beeline/spring/autoconfig/BeelineConfig.java
@@ -71,8 +71,8 @@ public class BeelineConfig {
                                                  final Optional<EventPostProcessor> maybePostProcessor) {
         // Spring will handle shutdown of the client, see javadoc of the Bean#destroyMethod annotation parameter
 
-        // if classic, then dataSet is beelineProperties.getDataSet()
-        // if nonclassic, then dataSet is beelineProperties.getServiceName()
+        // if classic, then dataset comes from configured dataset
+        // if nonclassic, then dataset comes from configured service name
         String dataset = beelineProperties.getDataset();
         String serviceName = beelineProperties.getServiceName();
         String writeKey = beelineProperties.getWriteKey();
@@ -105,7 +105,6 @@ public class BeelineConfig {
         }
 
         final HoneyClientBuilder builder = new HoneyClientBuilder()
-            // todo use dataset if classic
             .dataSet(dataset)
             .writeKey(writeKey)
             .transport(transport);

--- a/beeline-spring-boot-starter/src/main/java/io/honeycomb/beeline/spring/autoconfig/BeelineConfig.java
+++ b/beeline-spring-boot-starter/src/main/java/io/honeycomb/beeline/spring/autoconfig/BeelineConfig.java
@@ -83,8 +83,6 @@ public class BeelineConfig {
             if (ObjectUtils.isNullOrEmpty(dataset)) {
                 System.err.println("empty dataset");
                 dataset = defaultDatasetClassic;
-            } else {
-                dataset = dataset;
             }
         } else {
             if (!ObjectUtils.isNullOrEmpty(dataset)) {

--- a/beeline-spring-boot-starter/src/main/java/io/honeycomb/beeline/spring/autoconfig/BeelineProperties.java
+++ b/beeline-spring-boot-starter/src/main/java/io/honeycomb/beeline/spring/autoconfig/BeelineProperties.java
@@ -38,11 +38,11 @@ public class BeelineProperties {
     private URI apiHost;
     /**
      * A name to identify this service when tracing data is displayed within Honeycomb.
-     * If not set, this will try to fall back to using Spring's own "spring.application.name" property.
+     * If not set, this will fall back to {@code unknown_service:java}.
      */
     @NotEmpty(
-        message = "The Beeline requires a service name configured through this property or 'spring.application.name'")
-    @Value("${spring.application.name:}")
+        message = "The Beeline requires a service name to be configured. Using unknown_service:java as a fallback.")
+    @Value("unknown_service:java")
     private String serviceName;
     /**
      * When set to false, this will disable the beeline auto configuration, so it will not instrument your application.

--- a/beeline-spring-boot-starter/src/test/java/io/honeycomb/beeline/spring/autoconfig/BeelineAutoconfigTest.java
+++ b/beeline-spring-boot-starter/src/test/java/io/honeycomb/beeline/spring/autoconfig/BeelineAutoconfigTest.java
@@ -107,7 +107,7 @@ public class BeelineAutoconfigTest {
     }
 
     @Test
-    public void GIVEN_classicWriteKeyNoConfiguredServiceName_EXPECT_FallbackToSpringApplicationName() {
+    public void GIVEN_classicWriteKeyNoConfiguredServiceName_EXPECT_FallbackToUnknownService() {
         webApplicationContextRunner
             .withConfiguration(AutoConfigurations.of(BeelineAutoconfig.class))
             .withPropertyValues(
@@ -120,7 +120,7 @@ public class BeelineAutoconfigTest {
     }
 
     @Test
-    public void GIVEN_classicIngestKeyNoConfiguredServiceName_EXPECT_FallbackToSpringApplicationName() {
+    public void GIVEN_classicIngestKeyNoConfiguredServiceName_EXPECT_FallbackToUnknownService() {
         webApplicationContextRunner
             .withConfiguration(AutoConfigurations.of(BeelineAutoconfig.class))
             .withPropertyValues(

--- a/beeline-spring-boot-starter/src/test/java/io/honeycomb/beeline/spring/autoconfig/BeelineAutoconfigTest.java
+++ b/beeline-spring-boot-starter/src/test/java/io/honeycomb/beeline/spring/autoconfig/BeelineAutoconfigTest.java
@@ -46,6 +46,11 @@ import static org.mockito.Mockito.mock;
  */
 public class BeelineAutoconfigTest {
 
+    private static final String classicWriteKey = "e38be416d0d68f9ed1e96432ac1a3380";
+    private static final String classicIngestKey = "hcaic_1234567890123456789012345678901234567890123456789012345678";
+    private static final String nonClassicWriteKey = "d68f9ed1e96432ac1a3380";
+    private static final String nonClassicIngestKey = "hcxik_01hqk4k20cjeh63wca8vva5stw70nft6m5n8wr8f5mjx3762s8269j50wc";
+
     private ApplicationContextRunner contextRunner = new ApplicationContextRunner();
     private WebApplicationContextRunner webApplicationContextRunner = new WebApplicationContextRunner();
 
@@ -64,7 +69,7 @@ public class BeelineAutoconfigTest {
     );
 
     private final String[] defaultProps = {
-        "honeycomb.beeline.write-key=someKey",
+        "honeycomb.beeline.write-key=${nonClassicIngestKey}",
         "honeycomb.beeline.dataset=someData",
         "honeycomb.beeline.enabled=true",
         "honeycomb.beeline.service-name=someService"
@@ -102,16 +107,55 @@ public class BeelineAutoconfigTest {
     }
 
     @Test
-    public void GIVEN_noConfigureServiceName_EXPECT_FallbackToSpringApplicationName() {
+    public void GIVEN_classicWriteKeyNoConfiguredServiceName_EXPECT_FallbackToSpringApplicationName() {
         webApplicationContextRunner
             .withConfiguration(AutoConfigurations.of(BeelineAutoconfig.class))
             .withPropertyValues(
-                "honeycomb.beeline.write-key=someKey",
+                "honeycomb.beeline.write-key=${classicWriteKey}",
                 "honeycomb.beeline.dataset=someData",
                 "honeycomb.beeline.jdbc.enabled=false")
             .withPropertyValues("spring.application.name=TestApp")
 
             .run(context -> assertThat(context.getBean(BeelineProperties.class).getServiceName()).isEqualTo("TestApp"));
+    }
+
+    @Test
+    public void GIVEN_classicIngestKeyNoConfiguredServiceName_EXPECT_FallbackToSpringApplicationName() {
+        webApplicationContextRunner
+            .withConfiguration(AutoConfigurations.of(BeelineAutoconfig.class))
+            .withPropertyValues(
+                "honeycomb.beeline.write-key=${classicIngestKey}",
+                "honeycomb.beeline.dataset=someData",
+                "honeycomb.beeline.jdbc.enabled=false")
+            .withPropertyValues("spring.application.name=TestApp")
+
+            .run(context -> assertThat(context.getBean(BeelineProperties.class).getServiceName()).isEqualTo("TestApp"));
+    }
+
+    @Test
+    public void GIVEN_nonClassicWriteKeyNoConfiguredServiceName_EXPECT_FallbackToUnknownService() {
+        webApplicationContextRunner
+            .withConfiguration(AutoConfigurations.of(BeelineAutoconfig.class))
+            .withPropertyValues(
+                "honeycomb.beeline.write-key=${nonClassicWriteKey}",
+                "honeycomb.beeline.dataset=someData",
+                "honeycomb.beeline.jdbc.enabled=false")
+            .withPropertyValues("spring.application.name=TestApp")
+
+            .run(context -> assertThat(context.getBean(BeelineProperties.class).getServiceName()).isEqualTo("unknown_service:java"));
+    }
+
+    @Test
+    public void GIVEN_nonClassicIngestKeyNoConfiguredServiceName_EXPECT_FallbackToUnknownService() {
+        webApplicationContextRunner
+            .withConfiguration(AutoConfigurations.of(BeelineAutoconfig.class))
+            .withPropertyValues(
+                "honeycomb.beeline.write-key=${nonClassicIngestKey}",
+                "honeycomb.beeline.dataset=someData",
+                "honeycomb.beeline.jdbc.enabled=false")
+            .withPropertyValues("spring.application.name=TestApp")
+
+            .run(context -> assertThat(context.getBean(BeelineProperties.class).getServiceName()).isEqualTo("unknown_service:java"));
     }
 
     @Test

--- a/beeline-spring-boot-starter/src/test/java/io/honeycomb/beeline/spring/autoconfig/BeelineAutoconfigTest.java
+++ b/beeline-spring-boot-starter/src/test/java/io/honeycomb/beeline/spring/autoconfig/BeelineAutoconfigTest.java
@@ -116,7 +116,7 @@ public class BeelineAutoconfigTest {
                 "honeycomb.beeline.jdbc.enabled=false")
             .withPropertyValues("spring.application.name=TestApp")
 
-            .run(context -> assertThat(context.getBean(BeelineProperties.class).getServiceName()).isEqualTo("TestApp"));
+            .run(context -> assertThat(context.getBean(BeelineProperties.class).getServiceName()).isEqualTo("unknown_service:java"));
     }
 
     @Test
@@ -129,7 +129,7 @@ public class BeelineAutoconfigTest {
                 "honeycomb.beeline.jdbc.enabled=false")
             .withPropertyValues("spring.application.name=TestApp")
 
-            .run(context -> assertThat(context.getBean(BeelineProperties.class).getServiceName()).isEqualTo("TestApp"));
+            .run(context -> assertThat(context.getBean(BeelineProperties.class).getServiceName()).isEqualTo("unknown_service:java"));
     }
 
     @Test

--- a/beeline-spring-boot-starter/src/test/java/io/honeycomb/beeline/spring/mockmvctests/MockMvcTest.java
+++ b/beeline-spring-boot-starter/src/test/java/io/honeycomb/beeline/spring/mockmvctests/MockMvcTest.java
@@ -201,7 +201,7 @@ public class MockMvcTest {
         verify(transport).submit(eventCaptor.capture());
         final ResolvedEvent capturedEvent = eventCaptor.getValue();
         assertThat(capturedEvent.getDataset()).isEqualTo("testServiceName");
-        assertThat(capturedEvent.getWriteKey()).isEqualTo("testWriteKey");
+        assertThat(capturedEvent.getWriteKey()).isEqualTo("d68f9ed1e96432ac1a3380"); // nonClassicWriteKey
         assertThat(capturedEvent.getApiHost().toString()).isEqualTo("http://localhost:8089");
     }
 

--- a/beeline-spring-boot-starter/src/test/java/io/honeycomb/beeline/spring/mockmvctests/MockMvcTest.java
+++ b/beeline-spring-boot-starter/src/test/java/io/honeycomb/beeline/spring/mockmvctests/MockMvcTest.java
@@ -200,7 +200,7 @@ public class MockMvcTest {
 
         verify(transport).submit(eventCaptor.capture());
         final ResolvedEvent capturedEvent = eventCaptor.getValue();
-        assertThat(capturedEvent.getDataset()).isEqualTo("testDataset");
+        assertThat(capturedEvent.getDataset()).isEqualTo("testServiceName");
         assertThat(capturedEvent.getWriteKey()).isEqualTo("testWriteKey");
         assertThat(capturedEvent.getApiHost().toString()).isEqualTo("http://localhost:8089");
     }
@@ -211,7 +211,7 @@ public class MockMvcTest {
 
         final Map<String, Object> eventFields = captureEventData();
 
-        assertThat(eventFields).containsEntry("service_name", "IntegrationTestApp");
+        assertThat(eventFields).containsEntry("service_name", "testServiceName");
         assertThat(eventFields).containsEntry("name", "BasicGet");
         assertThat(eventFields).containsEntry("type", "http_server");
         assertThat((double) eventFields.get("duration_ms")).isGreaterThan(0);
@@ -563,12 +563,12 @@ public class MockMvcTest {
         final ResolvedEvent aopSpan = eventFields.get(0);
         final ResolvedEvent requestSpan = eventFields.get(1);
 
-        assertThat(aopSpan.getDataset()).isEqualTo("testDataset");
-        assertThat(requestSpan.getDataset()).isEqualTo("testDataset");
+        assertThat(aopSpan.getDataset()).isEqualTo("testServiceName");
+        assertThat(requestSpan.getDataset()).isEqualTo("testServiceName");
     }
 
     @Test
-    public void WHEN_makingARequestWithHoneycombHeaderNotSpecifyingAnyDataset_EXPECT_AllEventsToSendToConfiguredDataset() throws Exception {
+    public void WHEN_makingARequestWithHoneycombHeaderNotSpecifyingAnyDataset_EXPECT_AllEventsToSendToConfiguredServiceName() throws Exception {
         final PropagationContext context = new PropagationContext("current-trace-1", "parent-span-1", null, Collections.singletonMap("trace-field", "abc"));
         final Map<String, String> headers = Propagation.honeycombHeaderV1().encode(context).get();
 
@@ -581,8 +581,8 @@ public class MockMvcTest {
         final ResolvedEvent aopSpan = eventFields.get(0);
         final ResolvedEvent requestSpan = eventFields.get(1);
 
-        assertThat(aopSpan.getDataset()).isEqualTo("testDataset");
-        assertThat(requestSpan.getDataset()).isEqualTo("testDataset");
+        assertThat(aopSpan.getDataset()).isEqualTo("testServiceName");
+        assertThat(requestSpan.getDataset()).isEqualTo("testServiceName");
     }
 
     private List<ResolvedEvent> captureNoOfEvents(final int times) {

--- a/beeline-spring-boot-starter/src/test/java/io/honeycomb/beeline/spring/mockmvctests/MockMvcTestClassic.java
+++ b/beeline-spring-boot-starter/src/test/java/io/honeycomb/beeline/spring/mockmvctests/MockMvcTestClassic.java
@@ -1,0 +1,162 @@
+package io.honeycomb.beeline.spring.mockmvctests;
+
+import io.honeycomb.beeline.spring.autoconfig.BeelineAutoconfig;
+import io.honeycomb.beeline.tracing.Tracer;
+import io.honeycomb.beeline.tracing.propagation.Propagation;
+import io.honeycomb.beeline.tracing.propagation.PropagationContext;
+import io.honeycomb.libhoney.HoneyClient;
+import io.honeycomb.libhoney.eventdata.ResolvedEvent;
+import io.honeycomb.libhoney.responses.ResponseObservable;
+import io.honeycomb.libhoney.transport.Transport;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Mockito;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.autoconfigure.ImportAutoConfiguration;
+import org.springframework.boot.autoconfigure.aop.AopAutoConfiguration;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.MediaType;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.context.junit4.SpringRunner;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.MvcResult;
+import org.springframework.test.web.servlet.request.MockHttpServletRequestBuilder;
+import org.springframework.web.util.NestedServletException;
+
+import java.net.InetAddress;
+import java.net.UnknownHostException;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+import java.util.Map;
+
+import static com.google.common.collect.ImmutableMap.of;
+import static io.honeycomb.beeline.tracing.utils.TraceFieldConstants.META_SENT_BY_PARENT_FIELD;
+import static io.honeycomb.beeline.tracing.utils.TraceFieldConstants.REQUEST_ERROR_DETAIL_FIELD;
+import static io.honeycomb.beeline.tracing.utils.TraceFieldConstants.REQUEST_ERROR_FIELD;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.assertj.core.api.Assertions.entry;
+import static org.hamcrest.CoreMatchers.notNullValue;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoMoreInteractions;
+import static org.mockito.Mockito.when;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.asyncDispatch;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.content;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.request;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+/**
+ * These are mockmvc tests which simulate Spring MVC's web server environment. They are faster than fuller
+ * integration tests like {@link io.honeycomb.beeline.spring.e2e.End2EndTest}, but also have some limitations as the
+ * environment is mocked and doesn't always behave like the real thing.
+ * <p>
+ * The web server endpoints that are hit with the simulated requests are defined in {@link MockMvcTestController}.
+ * They are generally simple stubs to verify our implementation against a specific behaviour of Spring MVC framework.
+ */
+@SuppressWarnings({"unchecked", "SpringJavaInjectionPointsAutowiringInspection"})
+@RunWith(SpringRunner.class)
+@WebMvcTest
+@ImportAutoConfiguration({BeelineAutoconfig.class, AopAutoConfiguration.class})
+@ActiveProfiles("request-test-classic") // means application-request-test-classic.properties is picked up
+public class MockMvcTestClassic {
+
+    @Configuration
+    static class TestConfig {
+        @Bean
+        MockMvcTestController controller() {
+            return new MockMvcTestController();
+        }
+    }
+
+    @Autowired
+    private Tracer tracer;
+    @Autowired
+    private MockMvc mvc;
+    @Autowired
+    private HoneyClient client;
+    private ArgumentCaptor<ResolvedEvent> eventCaptor = ArgumentCaptor.forClass(ResolvedEvent.class);
+
+    // replace the transport from the BeelineAutoconfig with mock, so we can capture and inspect events to be sent to honeycomb
+    @MockBean
+    private Transport transport;
+
+    private void setTransportStubs() {
+        when(transport.submit(any(ResolvedEvent.class))).thenReturn(true);
+        when(transport.getResponseObservable()).thenReturn(mock(ResponseObservable.class));
+    }
+
+    @Before
+    public void setup() {
+        setTransportStubs();
+    }
+
+    private String[] problemFields = {
+        REQUEST_ERROR_FIELD,
+        REQUEST_ERROR_DETAIL_FIELD,
+        META_SENT_BY_PARENT_FIELD,
+    };
+
+    @Test
+    public void WHEN_GETing_EXPECT_spanToBeSubmittedWithRequiredApiAttributes() throws Exception {
+        mvc.perform(get("/basic-get")).andReturn().getResponse().getContentAsString();
+
+        verify(transport).submit(eventCaptor.capture());
+        final ResolvedEvent capturedEvent = eventCaptor.getValue();
+        assertThat(capturedEvent.getDataset()).isEqualTo("testDataset");
+        assertThat(capturedEvent.getWriteKey()).isEqualTo("e38be416d0d68f9ed1e96432ac1a3380");
+        assertThat(capturedEvent.getApiHost().toString()).isEqualTo("http://localhost:8089");
+    }
+
+    @Test
+    public void WHEN_makingARequestWithHoneycombHeaderSpecifyingADataset_EXPECT_AllEventsToIgnoreDatasetValueAndUseConfiguredDataset() throws Exception {
+        final PropagationContext context = new PropagationContext("current-trace-1", "parent-span-1", "myDataset", Collections.singletonMap("trace-field", "abc"));
+        final Map<String, String> headers = Propagation.honeycombHeaderV1().encode(context).get();
+
+        final MockHttpServletRequestBuilder builder = get("/annotation-span")
+            .header("x-application-header", "fish");
+        headers.forEach((k,v) -> builder.header(k, v));
+        mvc.perform(builder);
+
+        final List<ResolvedEvent> eventFields = captureNoOfEvents(2);
+        final ResolvedEvent aopSpan = eventFields.get(0);
+        final ResolvedEvent requestSpan = eventFields.get(1);
+
+        assertThat(aopSpan.getDataset()).isEqualTo("testDataset");
+        assertThat(requestSpan.getDataset()).isEqualTo("testDataset");
+    }
+
+    @Test
+    public void WHEN_makingARequestWithHoneycombHeaderNotSpecifyingAnyDataset_EXPECT_AllEventsToSendToConfiguredDataset() throws Exception {
+        final PropagationContext context = new PropagationContext("current-trace-1", "parent-span-1", null, Collections.singletonMap("trace-field", "abc"));
+        final Map<String, String> headers = Propagation.honeycombHeaderV1().encode(context).get();
+
+        final MockHttpServletRequestBuilder builder = get("/annotation-span")
+            .header("x-application-header", "fish");
+        headers.forEach((k,v) -> builder.header(k, v));
+        mvc.perform(builder);
+
+        final List<ResolvedEvent> eventFields = captureNoOfEvents(2);
+        final ResolvedEvent aopSpan = eventFields.get(0);
+        final ResolvedEvent requestSpan = eventFields.get(1);
+
+        assertThat(aopSpan.getDataset()).isEqualTo("testDataset");
+        assertThat(requestSpan.getDataset()).isEqualTo("testDataset");
+    }
+
+    private List<ResolvedEvent> captureNoOfEvents(final int times) {
+        Mockito.verify(transport, Mockito.times(times)).submit(eventCaptor.capture());
+        return eventCaptor.getAllValues();
+    }
+
+}

--- a/beeline-spring-boot-starter/src/test/java/io/honeycomb/beeline/spring/mockmvctests/MockMvcTestIngest.java
+++ b/beeline-spring-boot-starter/src/test/java/io/honeycomb/beeline/spring/mockmvctests/MockMvcTestIngest.java
@@ -1,0 +1,141 @@
+package io.honeycomb.beeline.spring.mockmvctests;
+
+import io.honeycomb.beeline.spring.autoconfig.BeelineAutoconfig;
+import io.honeycomb.beeline.tracing.Tracer;
+import io.honeycomb.beeline.tracing.propagation.Propagation;
+import io.honeycomb.beeline.tracing.propagation.PropagationContext;
+import io.honeycomb.libhoney.HoneyClient;
+import io.honeycomb.libhoney.eventdata.ResolvedEvent;
+import io.honeycomb.libhoney.responses.ResponseObservable;
+import io.honeycomb.libhoney.transport.Transport;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Mockito;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.autoconfigure.ImportAutoConfiguration;
+import org.springframework.boot.autoconfigure.aop.AopAutoConfiguration;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.context.junit4.SpringRunner;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.request.MockHttpServletRequestBuilder;
+
+import java.util.Collections;
+import java.util.List;
+import java.util.Map;
+
+import static io.honeycomb.beeline.tracing.utils.TraceFieldConstants.*;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.*;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+
+/**
+ * These are mockmvc tests which simulate Spring MVC's web server environment. They are faster than fuller
+ * integration tests like {@link io.honeycomb.beeline.spring.e2e.End2EndTest}, but also have some limitations as the
+ * environment is mocked and doesn't always behave like the real thing.
+ * <p>
+ * The web server endpoints that are hit with the simulated requests are defined in {@link MockMvcTestController}.
+ * They are generally simple stubs to verify our implementation against a specific behaviour of Spring MVC framework.
+ */
+@SuppressWarnings({"unchecked", "SpringJavaInjectionPointsAutowiringInspection"})
+@RunWith(SpringRunner.class)
+@WebMvcTest
+@ImportAutoConfiguration({BeelineAutoconfig.class, AopAutoConfiguration.class})
+@ActiveProfiles("request-test-ingest") // means application-request-test-ingest.properties is picked up
+public class MockMvcTestIngest {
+
+    @Configuration
+    static class TestConfig {
+        @Bean
+        MockMvcTestController controller() {
+            return new MockMvcTestController();
+        }
+    }
+
+    @Autowired
+    private Tracer tracer;
+    @Autowired
+    private MockMvc mvc;
+    @Autowired
+    private HoneyClient client;
+    private ArgumentCaptor<ResolvedEvent> eventCaptor = ArgumentCaptor.forClass(ResolvedEvent.class);
+
+    // replace the transport from the BeelineAutoconfig with mock, so we can capture and inspect events to be sent to honeycomb
+    @MockBean
+    private Transport transport;
+
+    private void setTransportStubs() {
+        when(transport.submit(any(ResolvedEvent.class))).thenReturn(true);
+        when(transport.getResponseObservable()).thenReturn(mock(ResponseObservable.class));
+    }
+
+    @Before
+    public void setup() {
+        setTransportStubs();
+    }
+
+    private String[] problemFields = {
+        REQUEST_ERROR_FIELD,
+        REQUEST_ERROR_DETAIL_FIELD,
+        META_SENT_BY_PARENT_FIELD,
+    };
+
+    @Test
+    public void WHEN_GETing_EXPECT_spanToBeSubmittedWithRequiredApiAttributes() throws Exception {
+        mvc.perform(get("/basic-get")).andReturn().getResponse().getContentAsString();
+
+        verify(transport).submit(eventCaptor.capture());
+        final ResolvedEvent capturedEvent = eventCaptor.getValue();
+        assertThat(capturedEvent.getDataset()).isEqualTo("testServiceName");
+        assertThat(capturedEvent.getWriteKey()).isEqualTo("hcxik_01hqk4k20cjeh63wca8vva5stw70nft6m5n8wr8f5mjx3762s8269j50wc");
+        assertThat(capturedEvent.getApiHost().toString()).isEqualTo("http://localhost:8089");
+    }
+
+    @Test
+    public void WHEN_makingARequestWithHoneycombHeaderSpecifyingADataset_EXPECT_AllEventsToIgnoreDatasetValueAndUseConfiguredDataset() throws Exception {
+        final PropagationContext context = new PropagationContext("current-trace-1", "parent-span-1", "myDataset", Collections.singletonMap("trace-field", "abc"));
+        final Map<String, String> headers = Propagation.honeycombHeaderV1().encode(context).get();
+
+        final MockHttpServletRequestBuilder builder = get("/annotation-span")
+            .header("x-application-header", "fish");
+        headers.forEach((k,v) -> builder.header(k, v));
+        mvc.perform(builder);
+
+        final List<ResolvedEvent> eventFields = captureNoOfEvents(2);
+        final ResolvedEvent aopSpan = eventFields.get(0);
+        final ResolvedEvent requestSpan = eventFields.get(1);
+
+        assertThat(aopSpan.getDataset()).isEqualTo("testServiceName");
+        assertThat(requestSpan.getDataset()).isEqualTo("testServiceName");
+    }
+
+    @Test
+    public void WHEN_makingARequestWithHoneycombHeaderNotSpecifyingAnyDataset_EXPECT_AllEventsToSendToConfiguredServiceName() throws Exception {
+        final PropagationContext context = new PropagationContext("current-trace-1", "parent-span-1", null, Collections.singletonMap("trace-field", "abc"));
+        final Map<String, String> headers = Propagation.honeycombHeaderV1().encode(context).get();
+
+        final MockHttpServletRequestBuilder builder = get("/annotation-span")
+            .header("x-application-header", "fish");
+        headers.forEach((k,v) -> builder.header(k, v));
+        mvc.perform(builder);
+
+        final List<ResolvedEvent> eventFields = captureNoOfEvents(2);
+        final ResolvedEvent aopSpan = eventFields.get(0);
+        final ResolvedEvent requestSpan = eventFields.get(1);
+
+        assertThat(aopSpan.getDataset()).isEqualTo("testServiceName");
+        assertThat(requestSpan.getDataset()).isEqualTo("testServiceName");
+    }
+
+    private List<ResolvedEvent> captureNoOfEvents(final int times) {
+        Mockito.verify(transport, Mockito.times(times)).submit(eventCaptor.capture());
+        return eventCaptor.getAllValues();
+    }
+
+}

--- a/beeline-spring-boot-starter/src/test/resources/application-path-pattern-test.properties
+++ b/beeline-spring-boot-starter/src/test/resources/application-path-pattern-test.properties
@@ -1,7 +1,7 @@
 honeycomb.beeline.dataset     :testDataset
 honeycomb.beeline.write-key   :testWriteKey
 honeycomb.beeline.api-host    :http://localhost:8089
-honeycomb.beeline.service-name:IntegrationTestApp
+honeycomb.beeline.service-name:testServiceName
 honeycomb.beeline.include-path-patterns: /allowlist/**
 honeycomb.beeline.exclude-path-patterns: /denylist/**
 honeycomb.beeline.log-honeycomb-responses: false

--- a/beeline-spring-boot-starter/src/test/resources/application-request-test-classic.properties
+++ b/beeline-spring-boot-starter/src/test/resources/application-request-test-classic.properties
@@ -1,6 +1,6 @@
 honeycomb.beeline.dataset     :testDataset
-# nonClassicWriteKey
-honeycomb.beeline.write-key   :d68f9ed1e96432ac1a3380
+# classicWriteKey
+honeycomb.beeline.write-key   :e38be416d0d68f9ed1e96432ac1a3380
 honeycomb.beeline.api-host    :http://localhost:8089
 honeycomb.beeline.service-name:testServiceName
 honeycomb.beeline.log-honeycomb-responses: false

--- a/beeline-spring-boot-starter/src/test/resources/application-request-test-ingest.properties
+++ b/beeline-spring-boot-starter/src/test/resources/application-request-test-ingest.properties
@@ -1,6 +1,6 @@
 honeycomb.beeline.dataset     :testDataset
-# nonClassicWriteKey
-honeycomb.beeline.write-key   :d68f9ed1e96432ac1a3380
+# nonClassicIngestKey
+honeycomb.beeline.write-key   :hcxik_01hqk4k20cjeh63wca8vva5stw70nft6m5n8wr8f5mjx3762s8269j50wc
 honeycomb.beeline.api-host    :http://localhost:8089
 honeycomb.beeline.service-name:testServiceName
 honeycomb.beeline.log-honeycomb-responses: false

--- a/beeline-spring-boot-starter/src/test/resources/application-request-test.properties
+++ b/beeline-spring-boot-starter/src/test/resources/application-request-test.properties
@@ -1,5 +1,5 @@
 honeycomb.beeline.dataset     :testDataset
 honeycomb.beeline.write-key   :testWriteKey
 honeycomb.beeline.api-host    :http://localhost:8089
-honeycomb.beeline.service-name:IntegrationTestApp
+honeycomb.beeline.service-name:testServiceName
 honeycomb.beeline.log-honeycomb-responses: false

--- a/example-spring/README.md
+++ b/example-spring/README.md
@@ -1,0 +1,33 @@
+# spring boot example app
+
+To test local code, add this to the root `pom.xml`:
+
+```xml
+    <distributionManagement>
+        <repository>
+            <id>local</id>
+            <url>file://${user.home}/.m2/repository</url>
+        </repository>
+    </distributionManagement>
+```
+
+Then at the root:
+
+```sh
+mvn clean install -DskipTests
+mvn deploy -DskipTests
+```
+
+Then in this directory
+
+```sh
+# run the app
+mvn spring-boot:run
+
+# run in debug mode
+mvn spring-boot:run -Dspring-boot.run.jvmArguments="-Xdebug -Xrunjdwp:transport=dt_socket,server=y,suspend=n,address=8080"
+```
+
+Hit the endpoint for a trace `curl localhost:8080`
+
+Tip: To ensure you're using the local copy, consider changing to a higher version in all the `pom.xml` files e.g. `2.42.42`

--- a/example-spring/pom.xml
+++ b/example-spring/pom.xml
@@ -1,0 +1,71 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+    <parent>
+          <groupId>io.honeycomb.beeline</groupId>
+          <artifactId>beeline-parent</artifactId>
+          <version>2.2.0</version>
+    </parent>
+
+    <groupId>io.honeycomb.beeline</groupId>
+    <artifactId>example-spring</artifactId>
+    <version>2.2.0</version>
+
+    <properties>
+        <maven.compiler.source>17</maven.compiler.source>
+        <maven.compiler.target>17</maven.compiler.target>
+        <java.version>17</java.version>
+        <spring.boot.version>2.4.3</spring.boot.version>
+    </properties>
+
+    <dependencyManagement>
+        <dependencies>
+            <dependency>
+                <groupId>org.springframework.boot</groupId>
+                <artifactId>spring-boot-dependencies</artifactId>
+                <version>${spring.boot.version}</version>
+                <type>pom</type>
+                <scope>import</scope>
+            </dependency>
+        </dependencies>
+    </dependencyManagement>
+
+	<dependencies>
+        <dependency>
+            <groupId>io.honeycomb.beeline</groupId>
+            <artifactId>beeline-spring-boot-starter</artifactId>
+            <version>${beelineVersion}</version>
+        </dependency>
+
+		<dependency>
+			<groupId>org.springframework.boot</groupId>
+			<artifactId>spring-boot-starter-web</artifactId>
+		</dependency>
+
+		<!-- tag::actuator[] -->
+		<dependency>
+			<groupId>org.springframework.boot</groupId>
+			<artifactId>spring-boot-starter-actuator</artifactId>
+		</dependency>
+		<!-- end::actuator[] -->
+
+		<!-- tag::tests[] -->
+		<dependency>
+			<groupId>org.springframework.boot</groupId>
+			<artifactId>spring-boot-starter-test</artifactId>
+			<scope>test</scope>
+		</dependency>
+		<!-- end::tests[] -->
+	</dependencies>
+
+	<build>
+		<plugins>
+			<plugin>
+				<groupId>org.springframework.boot</groupId>
+				<artifactId>spring-boot-maven-plugin</artifactId>
+			</plugin>
+		</plugins>
+	</build>
+</project>

--- a/example-spring/src/main/java/io/honeycomb/Application.java
+++ b/example-spring/src/main/java/io/honeycomb/Application.java
@@ -1,0 +1,13 @@
+package io.honeycomb;
+
+import org.springframework.boot.SpringApplication;
+import org.springframework.boot.autoconfigure.SpringBootApplication;
+
+@SpringBootApplication
+public class Application {
+    public static void main(String[] args) {
+        SpringApplication.run(Application.class, args);
+        System.out.println("Hello World!");
+    }
+
+}

--- a/example-spring/src/main/java/io/honeycomb/HelloController.java
+++ b/example-spring/src/main/java/io/honeycomb/HelloController.java
@@ -1,0 +1,13 @@
+package io.honeycomb;
+
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+public class HelloController {
+
+  @GetMapping("/")
+  public String index() {
+    return "Greetings from Spring Boot!";
+  }
+}

--- a/example-spring/src/main/resources/application.properties
+++ b/example-spring/src/main/resources/application.properties
@@ -1,0 +1,26 @@
+# (Required*) Dataset to send the Events/Spans to; *only used for Classic keys
+honeycomb.beeline.dataset=beeline-java-dataset
+
+# (Required) Give your application a name to identify the origin of your events
+honeycomb.beeline.service-name=beeline-java-service-name
+
+# (Required) Your Honeycomb account API key
+honeycomb.beeline.write-key=my-api-key
+
+# (Optional) For testing you can override Honeycomb's hostname and redirect Events/Spans.
+# honeycomb.beeline.api-host=https://api.honeycomb.io
+
+# (Optional) Sets the global sample rate of traces.
+#honeycomb.beeline.sample-rate=1
+
+# (Optional) Allows the entire Beeline AutoConfiguration to be disabled completely.
+#honeycomb.beeline.enabled=true
+
+# (Optional) Allows to switch off automatic instrumentation of the RestTemplate.
+#honeycomb.beeline.rest-template.enabled=true
+
+# (Optional) Enables a form of debug logging of responses from Honeycomb's server
+# honeycomb.beeline.log-honeycomb-responses=true
+
+# (Optional) List of paths that should be subject to tracing (ant path pattern)
+#honeycomb.beeline.include-path-patterns=/**

--- a/pom.xml
+++ b/pom.xml
@@ -30,6 +30,7 @@
         <module>beeline-spring-boot-starter</module>
         <module>beeline-spring-boot-sleuth-starter</module>
         <module>examples</module>
+        <module>example-spring</module>
     </modules>
 
     <scm>


### PR DESCRIPTION
## Which problem is this PR solving?

- When using a non-classic API key... `service.name` is not properly set, resulting in traces ending up in wrong dataset. For example, with `dataset=my-dataset` and `service.name=my-service`, traces should show up in `my-service` dataset.

## Short description of the changes

- set servicename in spring boot starter
- use process name instead of service name for default fallback
- don't throw on runtime exception
- use dataset for classic keys and service name for nonclassic keys
- update and add unit tests to assert ServiceName is properly used for dataset with nonclassic keys, and dataset for classic keys
- update fallback `service.name` attribute to be `unknown_service:java`.

Classic Key: set `honeycomb.beeline.dataset` and that is where data ends up in Honeycomb
NonClassic Key: set `honeycomb.beeline.service-name` and that is where data ends up in Honeycomb

**NOTE**: this is technically breaking. Data was never being sent to `service.name` dataset, so it doesn't change location in Honeycomb for classic keys. If using a Classic key, and the `service.name` attribute was left empty and relied on `spring.application.name`, it will now have `unknown_service:java` for that attribute but will continue to send to the configured dataset. If using a nonclassic key (any new user), data will be sent to the configured `service-name` attribute; if that is not set, it will be sent to `unknown_service:java` in Honeycomb. This should be called out in the release notes